### PR TITLE
Migrate from `leavesmc.top` to `leavesmc.org`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You can download the latest build (1.20.x) of Leaves by going [here](https://git
 
 You can also [build it yourself](https://github.com/LeavesMC/Leaves#building).
 
-You can visit our [documentation](https://docs.leavesmc.top/leaves) for more information.
+You can visit our [documentation](https://docs.leavesmc.org/leaves) for more information.
 
 ## How To (Plugin developers)
 Leaves-API:

--- a/README_cn.md
+++ b/README_cn.md
@@ -19,7 +19,7 @@ Leaves
 
 也可以通过 [此处](https://github.com/LeavesMC/Leaves/blob/master/README_cn.md#自行构建) 的指南自行构建
 
-如果你想要获得更多信息，那么你可以访问我们的 [文档](https://docs.leavesmc.top/zh/leaves)
+如果你想要获得更多信息，那么你可以访问我们的 [文档](https://docs.leavesmc.org/zh/leaves)
 
 ## 对于插件开发者
 Leaves-API:

--- a/patches/server/0001-Build-changes.patch
+++ b/patches/server/0001-Build-changes.patch
@@ -196,7 +196,7 @@ index c490a29bcf7410bc54959ee71375605964379ed5..367975d5e0c9846e5ce6d9cbdc3a977c
      private final String bukkitVersion = Versioning.getBukkitVersion();
      private final Logger logger = Logger.getLogger("Minecraft");
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 8d626fadcd4743b6472a2954d2b1b2ec89669814..ea26b89c056b0329d3f0925b023e4bd526ee8efa 100644
+index 8d626fadcd4743b6472a2954d2b1b2ec89669814..1068ed383232a71f6ada6677f4872267cc565325 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -301,7 +301,7 @@ public class Main {
@@ -204,7 +204,7 @@ index 8d626fadcd4743b6472a2954d2b1b2ec89669814..ea26b89c056b0329d3f0925b023e4bd5
                          // Paper start - This is some stupid bullshit
                          System.err.println("*** Warning, you've not updated in a while! ***");
 -                        System.err.println("*** Please download a new build as per instructions from https://papermc.io/downloads/paper ***"); // Paper
-+                        System.err.println("*** Please download a new build as per instructions from https://leavesmc.top/downloads/leaves ***"); //Paper // Leaves
++                        System.err.println("*** Please download a new build as per instructions from https://leavesmc.org/downloads/leaves ***"); //Paper // Leaves
                          //System.err.println("*** Server will start in 20 seconds ***");
                          //Thread.sleep(TimeUnit.SECONDS.toMillis(20));
                          // Paper end

--- a/patches/server/0004-Update-version-fetcher-repo.patch
+++ b/patches/server/0004-Update-version-fetcher-repo.patch
@@ -50,7 +50,7 @@ index 3fb07dae586c5511cb048b20264072bf6db54df8..008a3da71071128c6302d881ed51d1d8
      @Override
 diff --git a/src/main/java/top/leavesmc/leaves/util/LeavesVersionFetcher.java b/src/main/java/top/leavesmc/leaves/util/LeavesVersionFetcher.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..50b9aae7ea944bc8cbdb248c26f0245611a402bb
+index 0000000000000000000000000000000000000000..18d104d4dc1da05affc67acbfc3c81c981d2a75b
 --- /dev/null
 +++ b/src/main/java/top/leavesmc/leaves/util/LeavesVersionFetcher.java
 @@ -0,0 +1,78 @@
@@ -93,7 +93,7 @@ index 0000000000000000000000000000000000000000..50b9aae7ea944bc8cbdb248c26f02456
 +    private static int fetchDistanceFromLeavesApiV2(String mcVersion, String hash) {
 +        try {
 +            try (BufferedReader reader = Resources.asCharSource(
-+                new URL("https://api.leavesmc.top/v2/projects/leaves/versions/" + mcVersion + "/differ/" + hash),
++                new URL("https://api.leavesmc.org/v2/projects/leaves/versions/" + mcVersion + "/differ/" + hash),
 +                Charsets.UTF_8
 +            ).openBufferedStream()) {
 +                return Integer.parseInt(reader.readLine());

--- a/patches/server/0103-Leaves-update-command.patch
+++ b/patches/server/0103-Leaves-update-command.patch
@@ -53,10 +53,10 @@ index 0000000000000000000000000000000000000000..293117a6c54fdce70d69b93fe80ce021
 +}
 diff --git a/src/main/java/top/leavesmc/leaves/util/LeavesUpdateHelper.java b/src/main/java/top/leavesmc/leaves/util/LeavesUpdateHelper.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..1337d5fa8eb0c848bc93345844d8291e1617677d
+index 0000000000000000000000000000000000000000..8ed3d15ebea4d8cfa134f331bd49d38fb2219b9a
 --- /dev/null
 +++ b/src/main/java/top/leavesmc/leaves/util/LeavesUpdateHelper.java
-@@ -0,0 +1,234 @@
+@@ -0,0 +1,240 @@
 +package top.leavesmc.leaves.util;
 +
 +import com.google.common.base.Charsets;
@@ -251,6 +251,12 @@ index 0000000000000000000000000000000000000000..1337d5fa8eb0c848bc93345844d8291e
 +        try {
 +            HttpURLConnection connection = (HttpURLConnection) new URL("https://api.leavesmc.org/projects/leaves/versions/" + mcVersion + "/builds/latest").openConnection();
 +            connection.connect();
++            boolean useApiV2 = false;
++            if (connection.getResponseCode() / 100 != 2){
++                connection = (HttpURLConnection) new URL("https://api.leavesmc.org/v2/projects/leaves/versions/" + mcVersion + "/builds/latest").openConnection();
++                connection.connect();
++                useApiV2 = true;
++            };
 +            if (connection.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) return LeavesBuildInfo.NULL;
 +            try (BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream(), Charsets.UTF_8))) {
 +                JsonObject obj = new Gson().fromJson(reader, JsonObject.class);
@@ -271,8 +277,8 @@ index 0000000000000000000000000000000000000000..1337d5fa8eb0c848bc93345844d8291e
 +                    JsonObject downloadInfo = obj.get("downloads").getAsJsonObject().get("application").getAsJsonObject();
 +                    String name = downloadInfo.get("name").getAsString();
 +                    String sha256 = downloadInfo.get("sha256").getAsString();
-+                    String githubUrl = downloadInfo.get("url").getAsString();
-+                    String cdnUrl = downloadInfo.get("cdn_url").getAsString();
++                    String githubUrl = useApiV2 ? "https://api.leavesmc.org/v2/projects/leaves/versions/" + mcVersion + "/builds/" + build + "/downloads/" + name : downloadInfo.get("url").getAsString();
++                    String cdnUrl = useApiV2 ? "https://cdn.leavesmc.z0z0r4.top/cache/" + name : downloadInfo.get("cdn_url").getAsString();
 +                    return new LeavesBuildInfo(build, name, sha256, needUpdate, cdnUrl, githubUrl);
 +                } else {
 +                    return LeavesBuildInfo.NULL;

--- a/patches/server/0103-Leaves-update-command.patch
+++ b/patches/server/0103-Leaves-update-command.patch
@@ -53,7 +53,7 @@ index 0000000000000000000000000000000000000000..293117a6c54fdce70d69b93fe80ce021
 +}
 diff --git a/src/main/java/top/leavesmc/leaves/util/LeavesUpdateHelper.java b/src/main/java/top/leavesmc/leaves/util/LeavesUpdateHelper.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..e7060b91a27b1d0cddb14c155caaa0e78a043e20
+index 0000000000000000000000000000000000000000..1337d5fa8eb0c848bc93345844d8291e1617677d
 --- /dev/null
 +++ b/src/main/java/top/leavesmc/leaves/util/LeavesUpdateHelper.java
 @@ -0,0 +1,234 @@
@@ -249,7 +249,7 @@ index 0000000000000000000000000000000000000000..e7060b91a27b1d0cddb14c155caaa0e7
 +
 +    private static LeavesBuildInfo getLatestBuildInfo(String mcVersion, String gitHash) {
 +        try {
-+            HttpURLConnection connection = (HttpURLConnection) new URL("https://api.leavesmc.top/projects/leaves/versions/" + mcVersion + "/builds/latest").openConnection();
++            HttpURLConnection connection = (HttpURLConnection) new URL("https://api.leavesmc.org/projects/leaves/versions/" + mcVersion + "/builds/latest").openConnection();
 +            connection.connect();
 +            if (connection.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) return LeavesBuildInfo.NULL;
 +            try (BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream(), Charsets.UTF_8))) {

--- a/scripts/PushToAPI.sh
+++ b/scripts/PushToAPI.sh
@@ -24,8 +24,8 @@ jar_name="leaves-$mcversion.jar"
 jar_sha256=`sha256 $jar_name`
 
 # v1
-curl --location --request POST "https://api.leavesmc.top/new_release" --header "Content-Type: application/json" --data-raw "{\"project_id\":\"$project_id\",\"project_name\":\"$project_name\",\"version\":\"$mcversion\",\"time\":\"$ctime\",\"channel\":\"$channel\",\"promoted\":$promoted,\"changes\":\"$changes\",\"downloads\":{\"application\":{\"name\":\"$jar_name\",\"sha256\":\"$jar_sha256\",\"url\":\"https://github.com/LeavesMC/Leaves/releases/download/$tag/$jar_name\"}},\"secret\":\"$secret\"}"
-curl --location --request POST "https://api.leavesmc.top/upload_file" -F "file=@$jar_name" -F "filename=$jar_name" -F "filehash=$jar_sha256" -F "secret=$secret"
+curl --location --request POST "https://api.leavesmc.org/new_release" --header "Content-Type: application/json" --data-raw "{\"project_id\":\"$project_id\",\"project_name\":\"$project_name\",\"version\":\"$mcversion\",\"time\":\"$ctime\",\"channel\":\"$channel\",\"promoted\":$promoted,\"changes\":\"$changes\",\"downloads\":{\"application\":{\"name\":\"$jar_name\",\"sha256\":\"$jar_sha256\",\"url\":\"https://github.com/LeavesMC/Leaves/releases/download/$tag/$jar_name\"}},\"secret\":\"$secret\"}"
+curl --location --request POST "https://api.leavesmc.org/upload_file" -F "file=@$jar_name" -F "filename=$jar_name" -F "filehash=$jar_sha256" -F "secret=$secret"
 
 # v2
-curl --location --request POST "https://api.leavesmc.top/v2/commit/build" --header "Content-Type: application/json" --header "Authentication: Bearer $secret_v2" --data-raw "{\"project_id\":\"$project_id\",\"version\":\"$mcversion\",\"channel\":\"$channel\",\"changes\":\"$changes\",\"jar_name\":\"$jar_name\",\"sha256\":\"$jar_sha256\",\"tag\":\"$tag\"}"
+curl --location --request POST "https://api.leavesmc.org/v2/commit/build" --header "Content-Type: application/json" --header "Authentication: Bearer $secret_v2" --data-raw "{\"project_id\":\"$project_id\",\"version\":\"$mcversion\",\"channel\":\"$channel\",\"changes\":\"$changes\",\"jar_name\":\"$jar_name\",\"sha256\":\"$jar_sha256\",\"tag\":\"$tag\"}"


### PR DESCRIPTION
fix #195 

`repo.leavesmc.[top|org]`  没改因为后面 ssl 证书还是 .top 的。