### PR TITLE
Fix ServerboundPingRequest handle in bytebuf api

### DIFF
--- a/patches/api/0010-Bytebuf-API.patch
+++ b/patches/api/0010-Bytebuf-API.patch
@@ -210,10 +210,10 @@ index 0000000000000000000000000000000000000000..e246c0a8725fa3b2be065433652a19a5
 +}
 diff --git a/src/main/java/org/leavesmc/leaves/bytebuf/packet/PacketType.java b/src/main/java/org/leavesmc/leaves/bytebuf/packet/PacketType.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..4fd80d703653b8fb2f2bec329b1c5d04ae419d2d
+index 0000000000000000000000000000000000000000..89c45a056716d0644fe1b41d49a4bdcede53c795
 --- /dev/null
 +++ b/src/main/java/org/leavesmc/leaves/bytebuf/packet/PacketType.java
-@@ -0,0 +1,180 @@
+@@ -0,0 +1,182 @@
 +package org.leavesmc.leaves.bytebuf.packet;
 +
 +public enum PacketType {
@@ -392,5 +392,7 @@ index 0000000000000000000000000000000000000000..4fd80d703653b8fb2f2bec329b1c5d04
 +    ServerboundCustomPayload,
 +    ServerboundKeepAlive,
 +    ServerboundPong,
-+    ServerboundResourcePack
++    ServerboundResourcePack,
++    ServerboundPingRequest,
++    ClientboundPongResponse
 +}

--- a/patches/server/0135-Bytebuf-API.patch
+++ b/patches/server/0135-Bytebuf-API.patch
@@ -392,10 +392,10 @@ index 0000000000000000000000000000000000000000..707d784cf17926e869481c39b0da908e
 +}
 diff --git a/src/main/java/org/leavesmc/leaves/bytebuf/internal/InternalBytebufHandler.java b/src/main/java/org/leavesmc/leaves/bytebuf/internal/InternalBytebufHandler.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..c9c649b997283fc28e84660e49f128ab8aabaa7e
+index 0000000000000000000000000000000000000000..2c446d1657834324f015b1637221164ff61f04e1
 --- /dev/null
 +++ b/src/main/java/org/leavesmc/leaves/bytebuf/internal/InternalBytebufHandler.java
-@@ -0,0 +1,221 @@
+@@ -0,0 +1,225 @@
 +package org.leavesmc.leaves.bytebuf.internal;
 +
 +import com.google.common.cache.Cache;
@@ -505,8 +505,12 @@ index 0000000000000000000000000000000000000000..c9c649b997283fc28e84660e49f128ab
 +            } catch (ClassNotFoundException e) {
 +                try {
 +                    packetClass = Class.forName("net.minecraft.network.protocol.common." + packet.name() + "Packet");
-+                } catch (ClassNotFoundException ignored) {
-+                    continue;
++                } catch (ClassNotFoundException e2) {
++                    try {
++                        packetClass = Class.forName("net.minecraft.network.protocol.ping." + packet.name() + "Packet");
++                    } catch (ClassNotFoundException ignored) {
++                        continue;
++                    }
 +                }
 +            }
 +            try {


### PR DESCRIPTION
如题，问题是服务器面包在群里提的

F3+3会向服务器发Ping request包，然而bytebuf api中没有这个支持，导致cacheloader会获取到null并尝试存储，引发报错

ps: 鬼知道mojang为什么要把这个包用于登录前和游戏中两个部分啊（