### PR TITLE
disable bot death event

### DIFF
--- a/patches/server/0010-Fakeplayer-support.patch
+++ b/patches/server/0010-Fakeplayer-support.patch
@@ -480,6 +480,22 @@ index 2cde808bfa797256409879505ba205a71f381981..a007beca6c00bce4514889935b1762a3
          // Special case complex part, since there is no extra entity type for them
          if (entity instanceof EnderDragonPart complexPart) {
              if (complexPart.parentMob instanceof EnderDragon) {
+diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+index 9c7cd9387f90d061aec76f7f0451a1da8b42ea3d..7c6de0ad3b919043b95429a4e506d63d32543598 100644
+--- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
++++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+@@ -1018,7 +1018,10 @@ public class CraftEventFactory {
+         event.setKeepInventory(keepInventory);
+         event.setKeepLevel(victim.keepLevel); // SPIGOT-2222: pre-set keepLevel
+         populateFields(victim, event); // Paper - make cancellable
+-        Bukkit.getServer().getPluginManager().callEvent(event);
++        // Leaves start - disable bot death event
++        if (!(victim instanceof org.leavesmc.leaves.bot.ServerBot)) {
++            Bukkit.getServer().getPluginManager().callEvent(event);
++        } // Leaves end
+         // Paper start - make cancellable
+         if (event.isCancelled()) {
+             return event;
 diff --git a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
 index bb9383f1a457433f9db3e78d7913616280925200..55b41ca7630db143d70137324a9de8717397f0e8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java


### PR DESCRIPTION
- 还是类似 #246

虽然我觉得还是不太优雅。

会导致一些编辑死亡信息的插件也改不了。