### PR TITLE
Fix #317, #324, notify #309

### DIFF
--- a/patches/server/0010-Fakeplayer-support.patch
+++ b/patches/server/0010-Fakeplayer-support.patch
@@ -1555,7 +1555,7 @@ index 0000000000000000000000000000000000000000..0db337866c71283464d026a4f230016b
 +}
 diff --git a/src/main/java/org/leavesmc/leaves/bot/ServerBot.java b/src/main/java/org/leavesmc/leaves/bot/ServerBot.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..462d58ad184ebe6bd6f161bff1481745b5723cf0
+index 0000000000000000000000000000000000000000..b4cd4314423684ccadce65cb791bb7defd46a704
 --- /dev/null
 +++ b/src/main/java/org/leavesmc/leaves/bot/ServerBot.java
 @@ -0,0 +1,782 @@
@@ -2050,7 +2050,7 @@ index 0000000000000000000000000000000000000000..462d58ad184ebe6bd6f161bff1481745
 +            this.hurtTime -= 1;
 +        }
 +
-+        baseTick();
++        super.doTick();
 +
 +        this.lerpSteps = (int) this.zza;
 +        this.animStep = this.run;

--- a/patches/server/0010-Fakeplayer-support.patch
+++ b/patches/server/0010-Fakeplayer-support.patch
@@ -146,7 +146,7 @@ index b835b259d9e371ff18b1704249b290d1ecbe06e1..49e7d9bc75e029a8800f7369681e43ef
              }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 763cffdc2e1e2e7cc9af88cc46bbaa240a20fd0d..647a6c9dd39e113625377273281d74ae3f902f96 100644
+index 763cffdc2e1e2e7cc9af88cc46bbaa240a20fd0d..d6c5d43aea7f9c5175c47a7e9efe9d91ba25cfbf 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -212,7 +212,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player imple
@@ -197,7 +197,19 @@ index 763cffdc2e1e2e7cc9af88cc46bbaa240a20fd0d..647a6c9dd39e113625377273281d74ae
          if (this.levitationStartPos != null) {
              CriteriaTriggers.LEVITATION.trigger(this, this.levitationStartPos, this.tickCount - this.levitationStartTime);
          }
-@@ -1015,7 +1019,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player imple
+@@ -831,6 +835,11 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player imple
+ 
+     public void doTick() {
+         try {
++            if (this instanceof org.leavesmc.leaves.bot.ServerBot) {
++                super.tick();
++                return;
++            }
++
+             if (valid && !this.isSpectator() || !this.touchingUnloadedChunk()) { // Paper - don't tick dead players that are not in the world currently (pending respawn)
+                 super.tick();
+             }
+@@ -1015,7 +1024,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player imple
          List<DefaultDrop> loot = new java.util.ArrayList<>(this.getInventory().getContainerSize()); // Paper - Restore vanilla drops behavior
          boolean keepInventory = this.level().getGameRules().getBoolean(GameRules.RULE_KEEPINVENTORY) || this.isSpectator();
  
@@ -206,7 +218,7 @@ index 763cffdc2e1e2e7cc9af88cc46bbaa240a20fd0d..647a6c9dd39e113625377273281d74ae
              for (ItemStack item : this.getInventory().getContents()) {
                  if (!item.isEmpty() && !EnchantmentHelper.has(item, EnchantmentEffectComponents.PREVENT_EQUIPMENT_DROP)) {
                      loot.add(new DefaultDrop(item, stack -> this.drop(stack, true, false, false))); // Paper - Restore vanilla drops behavior; drop function taken from Inventory#dropAll (don't fire drop event)
-@@ -1417,6 +1421,13 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player imple
+@@ -1417,6 +1426,13 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player imple
                  this.lastSentHealth = -1.0F;
                  this.lastSentFood = -1;
  

--- a/patches/server/0038-Player-operation-limiter.patch
+++ b/patches/server/0038-Player-operation-limiter.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Player operation limiter
 This patch is Powered by plusls-carpet-addition(https://github.com/plusls/plusls-carpet-addition)
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 647a6c9dd39e113625377273281d74ae3f902f96..2852e569c11af9281f5e81659525898bcfea372a 100644
+index d6c5d43aea7f9c5175c47a7e9efe9d91ba25cfbf..3c30aae751580c204e5a7106588e9b4721fac743 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -302,6 +302,10 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player imple
@@ -28,7 +28,7 @@ index 647a6c9dd39e113625377273281d74ae3f902f96..2852e569c11af9281f5e81659525898b
          this.gameMode.tick();
          this.wardenSpawnTracker.tick();
          --this.spawnInvulnerableTime;
-@@ -2953,5 +2958,32 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player imple
+@@ -2958,5 +2963,32 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player imple
      public CraftPlayer getBukkitEntity() {
          return (CraftPlayer) super.getBukkitEntity();
      }

--- a/patches/server/0042-MC-Technical-Survival-Mode.patch
+++ b/patches/server/0042-MC-Technical-Survival-Mode.patch
@@ -52,10 +52,10 @@ index 5a97f8a853664a3ced63215a386286873a6c7a95..f10018a3f79744ce0c78ee3020ec0f5d
                  pearl.ownerUUID = null;
              }
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 2852e569c11af9281f5e81659525898bcfea372a..55e8802526effaa30fbf7ae5a1b5db7929d668a7 100644
+index 3c30aae751580c204e5a7106588e9b4721fac743..839faa453f3542c43b8a6320d3c86f0d5711858d 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1634,7 +1634,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player imple
+@@ -1639,7 +1639,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player imple
  
      @Override
      public boolean isInvulnerableTo(DamageSource damageSource) {

--- a/patches/server/0043-Return-nether-portal-fix.patch
+++ b/patches/server/0043-Return-nether-portal-fix.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Return nether portal fix
 This patch is powered by NetherPortalFix(https://github.com/TwelveIterationMods/NetherPortalFix)
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 55e8802526effaa30fbf7ae5a1b5db7929d668a7..cc51a2c43028e63fa4bcf6dadb7b5bc3d5a9f4bb 100644
+index 839faa453f3542c43b8a6320d3c86f0d5711858d..e87cf25ed2ff7d3cdfd6cebce4db70f8d0694934 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1437,6 +1437,21 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player imple
+@@ -1442,6 +1442,21 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player imple
                  PlayerChangedWorldEvent changeEvent = new PlayerChangedWorldEvent(this.getBukkitEntity(), worldserver1.getWorld());
                  this.level().getCraftServer().getPluginManager().callEvent(changeEvent);
                  // CraftBukkit end


### PR DESCRIPTION
这是一个很离谱的原因 来自于Mojang的抽象代码 也是我今天自己仔细看才找到的
所有的"假人不像真人"的问题都来自于这个

问题解析：
在之前的版本中, ServerBot#tick的调用链如下:
->ServerBot#tick
    ->ServerPlayer#tick
    ->ServerBot#doTick

注意: ServerPlayer#tick 不包括 super.tick，也就是 Player#tick 不是在这里调用的
Player#tick 来自于 ServerPlayer#tick ，也就是 ServerGamePacketListenerImpl#tick 产生的，而假人根本不会调用这个方法
而 doTick 没有调用 super 的内容，也不会调用到 Player#tick
这就导致了所有玩家相关的内容都没有被调用，自然也不像真人

修复后的调用链:
->ServerBot#tick
    ->ServerPlayer#tick
    ->ServerBot#doTick
        ->ServerPlayer#doTick
            ->Player#tick


已测试的食用和睡觉都正常工作，区块加载需要进一步测试