### PR TITLE
Fix knockback

### DIFF
--- a/patches/server/0010-Fakeplayer-support.patch
+++ b/patches/server/0010-Fakeplayer-support.patch
@@ -1918,7 +1918,7 @@ index 0000000000000000000000000000000000000000..0db337866c71283464d026a4f230016b
 +}
 diff --git a/src/main/java/org/leavesmc/leaves/bot/ServerBot.java b/src/main/java/org/leavesmc/leaves/bot/ServerBot.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..fa5e475b9be4ee9b049483096bfd25cb470b1217
+index 0000000000000000000000000000000000000000..d84b15b6e366e158a9ca99a63c05417f087e7c27
 --- /dev/null
 +++ b/src/main/java/org/leavesmc/leaves/bot/ServerBot.java
 @@ -0,0 +1,543 @@
@@ -2222,7 +2222,7 @@ index 0000000000000000000000000000000000000000..fa5e475b9be4ee9b049483096bfd25cb
 +
 +    @Override
 +    public void doTick() {
-+        //this.absMoveTo(this.getX(), this.getY(), this.getZ(), this.getYRot(), this.getXRot());
++        this.absMoveTo(this.getX(), this.getY(), this.getZ(), this.getYRot(), this.getXRot());
 +
 +        if (this.takeXpDelay > 0) {
 +            --this.takeXpDelay;

--- a/patches/server/0010-Fakeplayer-support.patch
+++ b/patches/server/0010-Fakeplayer-support.patch
@@ -1918,16 +1918,17 @@ index 0000000000000000000000000000000000000000..0db337866c71283464d026a4f230016b
 +}
 diff --git a/src/main/java/org/leavesmc/leaves/bot/ServerBot.java b/src/main/java/org/leavesmc/leaves/bot/ServerBot.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..d53e0784633071f185682c4ca584b2416324e63c
+index 0000000000000000000000000000000000000000..fa5e475b9be4ee9b049483096bfd25cb470b1217
 --- /dev/null
 +++ b/src/main/java/org/leavesmc/leaves/bot/ServerBot.java
-@@ -0,0 +1,535 @@
+@@ -0,0 +1,543 @@
 +package org.leavesmc.leaves.bot;
 +
 +import com.google.common.collect.ImmutableMap;
 +import com.mojang.authlib.GameProfile;
 +import com.mojang.authlib.properties.Property;
 +import io.papermc.paper.adventure.PaperAdventure;
++import io.papermc.paper.event.entity.EntityKnockbackEvent;
 +import net.minecraft.core.BlockPos;
 +import net.minecraft.network.chat.Component;
 +import net.minecraft.network.protocol.Packet;
@@ -1947,6 +1948,7 @@ index 0000000000000000000000000000000000000000..d53e0784633071f185682c4ca584b241
 +import net.minecraft.world.damagesource.DamageSource;
 +import net.minecraft.world.entity.Entity;
 +import net.minecraft.world.entity.EquipmentSlot;
++import net.minecraft.world.entity.ai.attributes.Attributes;
 +import net.minecraft.world.entity.item.ItemEntity;
 +import net.minecraft.world.entity.player.Player;
 +import net.minecraft.world.inventory.ChestMenu;
@@ -1956,6 +1958,7 @@ index 0000000000000000000000000000000000000000..d53e0784633071f185682c4ca584b241
 +import net.minecraft.world.level.gameevent.GameEvent;
 +import net.minecraft.world.level.portal.DimensionTransition;
 +import net.minecraft.world.phys.EntityHitResult;
++import net.minecraft.world.phys.Vec3;
 +import org.bukkit.Bukkit;
 +import org.bukkit.Location;
 +import org.bukkit.Material;
@@ -2003,6 +2006,8 @@ index 0000000000000000000000000000000000000000..d53e0784633071f185682c4ca584b241
 +    public int notSleepTicks;
 +
 +    public int removeTaskId = -1;
++
++    private Vec3 knockback = Vec3.ZERO;
 +
 +    public ServerBot(MinecraftServer server, ServerLevel world, GameProfile profile) {
 +        super(server, world, profile, ClientInformation.createDefault());
@@ -2217,7 +2222,7 @@ index 0000000000000000000000000000000000000000..d53e0784633071f185682c4ca584b241
 +
 +    @Override
 +    public void doTick() {
-+        this.absMoveTo(this.getX(), this.getY(), this.getZ(), this.getYRot(), this.getXRot());
++        //this.absMoveTo(this.getX(), this.getY(), this.getZ(), this.getYRot(), this.getXRot());
 +
 +        if (this.takeXpDelay > 0) {
 +            --this.takeXpDelay;
@@ -2241,6 +2246,8 @@ index 0000000000000000000000000000000000000000..d53e0784633071f185682c4ca584b241
 +        }
 +
 +        this.updateIsUnderwater();
++        this.addDeltaMovement(knockback);
++        knockback = Vec3.ZERO;
 +        this.livingEntityTick();
 +        // this.moveCloak();
 +
@@ -2268,7 +2275,7 @@ index 0000000000000000000000000000000000000000..d53e0784633071f185682c4ca584b241
 +        return this.getBukkitPlayer().getLocation();
 +    }
 +
-+    /*
++
 +    @Override
 +    public void knockback(double strength, double x, double z, @Nullable Entity attacker, @NotNull EntityKnockbackEvent.Cause cause) {
 +        strength *= 1.0D - this.getAttributeValue(Attributes.KNOCKBACK_RESISTANCE);
@@ -2280,6 +2287,7 @@ index 0000000000000000000000000000000000000000..d53e0784633071f185682c4ca584b241
 +        }
 +    }
 +
++    /*
 +    private void updateLocation() {
 +        this.velocity = new Vec3(this.xxa, this.yya, this.zza);
 +


### PR DESCRIPTION
如题

原版击退会直接设置delta movement, 可能会在 tick 前被覆盖, 像以前一样 override 然后单独记录即可