### PR TITLE
Fix CommandUtil(#348)

### DIFF
--- a/patches/server/0004-Leaves-Server-Utils.patch
+++ b/patches/server/0004-Leaves-Server-Utils.patch
@@ -77,6 +77,95 @@ index 0000000000000000000000000000000000000000..47347a3bdab2ff9818bf8198291d2dab
 +        this.warning(msg + ", " + exception.getCause() + ": " + exception.getMessage());
 +    }
 +}
+diff --git a/src/main/java/org/leavesmc/leaves/command/LeavesCommandUtil.java b/src/main/java/org/leavesmc/leaves/command/LeavesCommandUtil.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..f50c3871e3ab435abc6de5bfb67b85b09d235733
+--- /dev/null
++++ b/src/main/java/org/leavesmc/leaves/command/LeavesCommandUtil.java
+@@ -0,0 +1,82 @@
++package org.leavesmc.leaves.command;
++
++import com.google.common.base.Functions;
++import com.google.common.collect.Iterables;
++import com.google.common.collect.Lists;
++import io.papermc.paper.command.PaperCommand;
++import net.minecraft.resources.ResourceLocation;
++import org.bukkit.command.CommandSender;
++import org.checkerframework.checker.nullness.qual.NonNull;
++import org.checkerframework.framework.qual.DefaultQualifier;
++
++import java.util.ArrayList;
++import java.util.Arrays;
++import java.util.Collection;
++import java.util.Iterator;
++import java.util.List;
++
++@DefaultQualifier(NonNull.class)
++public class LeavesCommandUtil {
++
++    private LeavesCommandUtil() {
++    }
++
++    // Code from Mojang - copyright them
++    public static List<String> getListMatchingLast(
++            final CommandSender sender,
++            final String[] args,
++            final String... matches
++    ) {
++        return getListMatchingLast(sender, args, Arrays.asList(matches));
++    }
++
++    public static boolean matches(final String s, final String s1) {
++        return s1.regionMatches(true, 0, s, 0, s.length());
++    }
++
++    public static List<String> getListMatchingLast(
++            final CommandSender sender,
++            final String[] strings,
++            final Collection<?> collection
++    ) {
++        return getListMatchingLast(sender, strings, collection, LeavesCommand.BASE_PERM, "bukkit.command.leaves");
++    }
++
++    public static List<String> getListMatchingLast(
++            final CommandSender sender,
++            final String[] strings,
++            final Collection<?> collection,
++            final String basePermission,
++            final String overridePermission
++    ) {
++        String last = strings[strings.length - 1];
++        ArrayList<String> results = Lists.newArrayList();
++
++        if (!collection.isEmpty()) {
++            Iterator iterator = Iterables.transform(collection, Functions.toStringFunction()).iterator();
++
++            while (iterator.hasNext()) {
++                String s1 = (String) iterator.next();
++
++                if (matches(last, s1) && (sender.hasPermission(basePermission + s1) || sender.hasPermission(overridePermission))) {
++                    results.add(s1);
++                }
++            }
++
++            if (results.isEmpty()) {
++                iterator = collection.iterator();
++
++                while (iterator.hasNext()) {
++                    Object object = iterator.next();
++
++                    if (object instanceof ResourceLocation && matches(last, ((ResourceLocation) object).getPath())) {
++                        results.add(String.valueOf(object));
++                    }
++                }
++            }
++        }
++
++        return results;
++    }
++    // end copy stuff
++}
+\ No newline at end of file
 diff --git a/src/main/java/org/leavesmc/leaves/util/AsyncExecutor.java b/src/main/java/org/leavesmc/leaves/util/AsyncExecutor.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..067e351f6e96f2ac1a46d78dc952b2e845c1efef

--- a/patches/server/0006-Leaves-Server-Config-And-Command.patch
+++ b/patches/server/0006-Leaves-Server-Config-And-Command.patch
@@ -1324,7 +1324,7 @@ index 0000000000000000000000000000000000000000..4b61fccc71d98a7b69bb7f88fb88ea0a
 +}
 diff --git a/src/main/java/org/leavesmc/leaves/command/subcommands/ConfigCommand.java b/src/main/java/org/leavesmc/leaves/command/subcommands/ConfigCommand.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..ba3fc98fb860e21fd0f28ae9dd59f1257b739e56
+index 0000000000000000000000000000000000000000..78471bde136d982f19f23beb3b121e4b254d124b
 --- /dev/null
 +++ b/src/main/java/org/leavesmc/leaves/command/subcommands/ConfigCommand.java
 @@ -0,0 +1,83 @@
@@ -1395,13 +1395,13 @@ index 0000000000000000000000000000000000000000..ba3fc98fb860e21fd0f28ae9dd59f125
 +        switch (args.length) {
 +            case 1 -> {
 +                List<String> list = new ArrayList<>(GlobalConfigManager.getVerifiedConfigPaths());
-+                return LeavesCommandUtil.getListMatchingLast(sender, args, list, "bukkit.command.leaves.config.", "bukkit.command.leaves.config");
++                return LeavesCommandUtil.getListMatchingLast(sender, args, list);
 +            }
 +
 +            case 2 -> {
 +                GlobalConfigManager.VerifiedConfig verifiedConfig = GlobalConfigManager.getVerifiedConfig(args[0]);
 +                if (verifiedConfig != null) {
-+                    return LeavesCommandUtil.getListMatchingLast(sender, args, verifiedConfig.verify().valueSuggest(), "", "bukkit.command.leaves.config");
++                    return LeavesCommandUtil.getListMatchingLast(sender, args, verifiedConfig.verify().valueSuggest());
 +                } else {
 +                    return Collections.singletonList("<ERROR CONFIG>");
 +                }

--- a/patches/server/0006-Leaves-Server-Config-And-Command.patch
+++ b/patches/server/0006-Leaves-Server-Config-And-Command.patch
@@ -1177,13 +1177,12 @@ index 0000000000000000000000000000000000000000..4ca3508475bbd9771768704e300fe12b
 +}
 diff --git a/src/main/java/org/leavesmc/leaves/command/LeavesCommand.java b/src/main/java/org/leavesmc/leaves/command/LeavesCommand.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..ebd62b1d3a60d3e22e3849047293e1f62533eae7
+index 0000000000000000000000000000000000000000..393163c80b9e2ce04b089e90d20eefd7b7ad8366
 --- /dev/null
 +++ b/src/main/java/org/leavesmc/leaves/command/LeavesCommand.java
-@@ -0,0 +1,118 @@
+@@ -0,0 +1,117 @@
 +package org.leavesmc.leaves.command;
 +
-+import io.papermc.paper.command.CommandUtil;
 +import it.unimi.dsi.fastutil.Pair;
 +import net.minecraft.Util;
 +import org.bukkit.Bukkit;
@@ -1252,7 +1251,7 @@ index 0000000000000000000000000000000000000000..ebd62b1d3a60d3e22e3849047293e1f6
 +    @Override
 +    public List<String> tabComplete(final @NotNull CommandSender sender, final @NotNull String alias, final String[] args, final @Nullable Location location) throws IllegalArgumentException {
 +        if (args.length <= 1) {
-+            return CommandUtil.getListMatchingLast(sender, args, COMPLETABLE_SUBCOMMANDS);
++            return LeavesCommandUtil.getListMatchingLast(sender, args, COMPLETABLE_SUBCOMMANDS);
 +        }
 +
 +        final @Nullable Pair<String, LeavesSubcommand> subCommand = resolveCommand(args[0]);
@@ -1325,17 +1324,17 @@ index 0000000000000000000000000000000000000000..4b61fccc71d98a7b69bb7f88fb88ea0a
 +}
 diff --git a/src/main/java/org/leavesmc/leaves/command/subcommands/ConfigCommand.java b/src/main/java/org/leavesmc/leaves/command/subcommands/ConfigCommand.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..e24d89294707e53dd54027133087a439748546d5
+index 0000000000000000000000000000000000000000..ba3fc98fb860e21fd0f28ae9dd59f1257b739e56
 --- /dev/null
 +++ b/src/main/java/org/leavesmc/leaves/command/subcommands/ConfigCommand.java
 @@ -0,0 +1,83 @@
 +package org.leavesmc.leaves.command.subcommands;
 +
-+import io.papermc.paper.command.CommandUtil;
 +import net.kyori.adventure.text.Component;
 +import net.kyori.adventure.text.JoinConfiguration;
 +import net.kyori.adventure.text.format.NamedTextColor;
 +import org.bukkit.command.CommandSender;
++import org.leavesmc.leaves.command.LeavesCommandUtil;
 +import org.leavesmc.leaves.command.LeavesSubcommand;
 +import org.leavesmc.leaves.config.GlobalConfigManager;
 +
@@ -1396,13 +1395,13 @@ index 0000000000000000000000000000000000000000..e24d89294707e53dd54027133087a439
 +        switch (args.length) {
 +            case 1 -> {
 +                List<String> list = new ArrayList<>(GlobalConfigManager.getVerifiedConfigPaths());
-+                return CommandUtil.getListMatchingLast(sender, args, list);
++                return LeavesCommandUtil.getListMatchingLast(sender, args, list, "bukkit.command.leaves.config.", "bukkit.command.leaves.config");
 +            }
 +
 +            case 2 -> {
 +                GlobalConfigManager.VerifiedConfig verifiedConfig = GlobalConfigManager.getVerifiedConfig(args[0]);
 +                if (verifiedConfig != null) {
-+                    return CommandUtil.getListMatchingLast(sender, args, verifiedConfig.verify().valueSuggest());
++                    return LeavesCommandUtil.getListMatchingLast(sender, args, verifiedConfig.verify().valueSuggest(), "", "bukkit.command.leaves.config");
 +                } else {
 +                    return Collections.singletonList("<ERROR CONFIG>");
 +                }

--- a/patches/server/0010-Fakeplayer-support.patch
+++ b/patches/server/0010-Fakeplayer-support.patch
@@ -626,13 +626,12 @@ index 4632eb883e9f5efde520ee543bcad25827c0da2c..d710803137a325f34e0628405d5ddfd0
              return event;
 diff --git a/src/main/java/org/leavesmc/leaves/bot/BotCommand.java b/src/main/java/org/leavesmc/leaves/bot/BotCommand.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..5a1054414f5313b59d38d89fb84987cad397ff12
+index 0000000000000000000000000000000000000000..789ad3dd37baf80ac5597a37464cbbaceeb55d70
 --- /dev/null
 +++ b/src/main/java/org/leavesmc/leaves/bot/BotCommand.java
 @@ -0,0 +1,543 @@
 +package org.leavesmc.leaves.bot;
 +
-+import io.papermc.paper.command.CommandUtil;
 +import net.kyori.adventure.text.Component;
 +import net.kyori.adventure.text.format.NamedTextColor;
 +import org.bukkit.Bukkit;
@@ -656,6 +655,7 @@ index 0000000000000000000000000000000000000000..5a1054414f5313b59d38d89fb84987ca
 +import org.leavesmc.leaves.bot.agent.Configs;
 +import org.leavesmc.leaves.bot.agent.actions.CraftCustomBotAction;
 +import org.leavesmc.leaves.command.CommandArgumentResult;
++import org.leavesmc.leaves.command.LeavesCommandUtil;
 +import org.leavesmc.leaves.entity.Bot;
 +import org.leavesmc.leaves.event.bot.BotActionStopEvent;
 +import org.leavesmc.leaves.event.bot.BotConfigModifyEvent;
@@ -762,7 +762,7 @@ index 0000000000000000000000000000000000000000..5a1054414f5313b59d38d89fb84987ca
 +            }
 +        }
 +
-+        return CommandUtil.getListMatchingLast(sender, args, list);
++        return LeavesCommandUtil.getListMatchingLast(sender, args, list, "bukkit.command.bot.", "bukkit.command.bot");
 +    }
 +
 +    @Override
@@ -4397,6 +4397,18 @@ index 0000000000000000000000000000000000000000..a3f978318a67c3c5e147a50eb2b6c01c
 +        this.value = nbt.getBoolean("spawn_phantom");
 +    }
 +}
+diff --git a/src/main/java/org/leavesmc/leaves/command/LeavesCommandUtil.java b/src/main/java/org/leavesmc/leaves/command/LeavesCommandUtil.java
+index f50c3871e3ab435abc6de5bfb67b85b09d235733..d110bf39788503ec662d6f0c737ce9aa2ab809e9 100644
+--- a/src/main/java/org/leavesmc/leaves/command/LeavesCommandUtil.java
++++ b/src/main/java/org/leavesmc/leaves/command/LeavesCommandUtil.java
+@@ -3,7 +3,6 @@ package org.leavesmc.leaves.command;
+ import com.google.common.base.Functions;
+ import com.google.common.collect.Iterables;
+ import com.google.common.collect.Lists;
+-import io.papermc.paper.command.PaperCommand;
+ import net.minecraft.resources.ResourceLocation;
+ import org.bukkit.command.CommandSender;
+ import org.checkerframework.checker.nullness.qual.NonNull;
 diff --git a/src/main/java/org/leavesmc/leaves/entity/CraftBot.java b/src/main/java/org/leavesmc/leaves/entity/CraftBot.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..46aec2f954919f487e22ab953062b6889fe3e58b

--- a/patches/server/0093-Leaves-Updater.patch
+++ b/patches/server/0093-Leaves-Updater.patch
@@ -8,10 +8,10 @@ Subject: [PATCH] Leaves Updater
 Co-authored-by: MC_XiaoHei <xiaohei.xor7studio@foxmail.com>
 
 diff --git a/src/main/java/org/leavesmc/leaves/command/LeavesCommand.java b/src/main/java/org/leavesmc/leaves/command/LeavesCommand.java
-index ebd62b1d3a60d3e22e3849047293e1f62533eae7..e964f05c5c0f2d1d9b4c0a3459076e4b95f0f4e8 100644
+index 393163c80b9e2ce04b089e90d20eefd7b7ad8366..41f4245f558f1c41ea84891b920f1d03dcb07066 100644
 --- a/src/main/java/org/leavesmc/leaves/command/LeavesCommand.java
 +++ b/src/main/java/org/leavesmc/leaves/command/LeavesCommand.java
-@@ -33,6 +33,7 @@ public final class LeavesCommand extends Command {
+@@ -32,6 +32,7 @@ public final class LeavesCommand extends Command {
      private static final Map<String, LeavesSubcommand> SUBCOMMANDS = Util.make(() -> {
          final Map<Set<String>, LeavesSubcommand> commands = new HashMap<>();
          commands.put(Set.of("config"), new ConfigCommand());

--- a/patches/server/0094-Force-peaceful-mode-switch.patch
+++ b/patches/server/0094-Force-peaceful-mode-switch.patch
@@ -122,10 +122,10 @@ index ea49d32a728fafe1dbd8b6c4f60b552550e78cd2..4d1bdc0cea3e1ea52e293d509f4a25ca
          if (!this.persistentDataContainer.isEmpty()) {
              c.put("BukkitValues", this.persistentDataContainer.toTagCompound());
 diff --git a/src/main/java/org/leavesmc/leaves/command/LeavesCommand.java b/src/main/java/org/leavesmc/leaves/command/LeavesCommand.java
-index e964f05c5c0f2d1d9b4c0a3459076e4b95f0f4e8..b28ca267a841f33ba18fff5587a6b0e677dc1ea1 100644
+index 41f4245f558f1c41ea84891b920f1d03dcb07066..92a8c3e4fc400988b3d984e7632a8149a2ce152e 100644
 --- a/src/main/java/org/leavesmc/leaves/command/LeavesCommand.java
 +++ b/src/main/java/org/leavesmc/leaves/command/LeavesCommand.java
-@@ -34,6 +34,7 @@ public final class LeavesCommand extends Command {
+@@ -33,6 +33,7 @@ public final class LeavesCommand extends Command {
          final Map<Set<String>, LeavesSubcommand> commands = new HashMap<>();
          commands.put(Set.of("config"), new ConfigCommand());
          commands.put(Set.of("update"), new UpdateCommand());
@@ -135,13 +135,12 @@ index e964f05c5c0f2d1d9b4c0a3459076e4b95f0f4e8..b28ca267a841f33ba18fff5587a6b0e6
              .flatMap(entry -> entry.getKey().stream().map(s -> Map.entry(s, entry.getValue())))
 diff --git a/src/main/java/org/leavesmc/leaves/command/subcommands/PeacefulModeSwitchCommand.java b/src/main/java/org/leavesmc/leaves/command/subcommands/PeacefulModeSwitchCommand.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..4c7895c94f7adaf0a7fb7c31327786b14768632e
+index 0000000000000000000000000000000000000000..76019d286d228dcb5bea991cb55ee6c5d6bd58eb
 --- /dev/null
 +++ b/src/main/java/org/leavesmc/leaves/command/subcommands/PeacefulModeSwitchCommand.java
 @@ -0,0 +1,87 @@
 +package org.leavesmc.leaves.command.subcommands;
 +
-+import io.papermc.paper.command.CommandUtil;
 +import net.kyori.adventure.text.Component;
 +import net.kyori.adventure.text.JoinConfiguration;
 +import net.kyori.adventure.text.format.NamedTextColor;
@@ -153,6 +152,7 @@ index 0000000000000000000000000000000000000000..4c7895c94f7adaf0a7fb7c31327786b1
 +import org.bukkit.command.CommandSender;
 +import org.bukkit.craftbukkit.CraftWorld;
 +import org.bukkit.entity.Player;
++import org.leavesmc.leaves.command.LeavesCommandUtil;
 +import org.leavesmc.leaves.command.LeavesSubcommand;
 +
 +import java.util.ArrayList;
@@ -215,7 +215,7 @@ index 0000000000000000000000000000000000000000..4c7895c94f7adaf0a7fb7c31327786b1
 +
 +    @Override
 +    public List<String> tabComplete(final CommandSender sender, final String subCommand, final String[] args) {
-+        return CommandUtil.getListMatchingLast(sender, args, this.suggestPeacefulModeSwitch(args));
++        return LeavesCommandUtil.getListMatchingLast(sender, args, this.suggestPeacefulModeSwitch(args), "", "bukkit.command.leaves");
 +    }
 +
 +    private List<String> suggestPeacefulModeSwitch(final String[] args) {

--- a/patches/server/0094-Force-peaceful-mode-switch.patch
+++ b/patches/server/0094-Force-peaceful-mode-switch.patch
@@ -135,7 +135,7 @@ index 41f4245f558f1c41ea84891b920f1d03dcb07066..92a8c3e4fc400988b3d984e7632a8149
              .flatMap(entry -> entry.getKey().stream().map(s -> Map.entry(s, entry.getValue())))
 diff --git a/src/main/java/org/leavesmc/leaves/command/subcommands/PeacefulModeSwitchCommand.java b/src/main/java/org/leavesmc/leaves/command/subcommands/PeacefulModeSwitchCommand.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..76019d286d228dcb5bea991cb55ee6c5d6bd58eb
+index 0000000000000000000000000000000000000000..1fe1d08cfb6caefc67cea27ac8fc188b8d6675c5
 --- /dev/null
 +++ b/src/main/java/org/leavesmc/leaves/command/subcommands/PeacefulModeSwitchCommand.java
 @@ -0,0 +1,87 @@
@@ -215,7 +215,7 @@ index 0000000000000000000000000000000000000000..76019d286d228dcb5bea991cb55ee6c5
 +
 +    @Override
 +    public List<String> tabComplete(final CommandSender sender, final String subCommand, final String[] args) {
-+        return LeavesCommandUtil.getListMatchingLast(sender, args, this.suggestPeacefulModeSwitch(args), "", "bukkit.command.leaves");
++        return LeavesCommandUtil.getListMatchingLast(sender, args, this.suggestPeacefulModeSwitch(args));
 +    }
 +
 +    private List<String> suggestPeacefulModeSwitch(final String[] args) {

--- a/patches/server/0099-Wool-Hopper-Counter.patch
+++ b/patches/server/0099-Wool-Hopper-Counter.patch
@@ -75,7 +75,7 @@ index 92a8c3e4fc400988b3d984e7632a8149a2ce152e..99823283690fcc1e6c0f76d8dcbcca9d
              .flatMap(entry -> entry.getKey().stream().map(s -> Map.entry(s, entry.getValue())))
 diff --git a/src/main/java/org/leavesmc/leaves/command/subcommands/CounterCommand.java b/src/main/java/org/leavesmc/leaves/command/subcommands/CounterCommand.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..8a24409770026450bd1f8e80d006573926b13c58
+index 0000000000000000000000000000000000000000..06b4d287bf545a51b9eeb7cd24fdc6a0c05271d9
 --- /dev/null
 +++ b/src/main/java/org/leavesmc/leaves/command/subcommands/CounterCommand.java
 @@ -0,0 +1,121 @@
@@ -182,12 +182,12 @@ index 0000000000000000000000000000000000000000..8a24409770026450bd1f8e80d0065739
 +                List<String> list = new ArrayList<>(Arrays.stream(DyeColor.values()).map(DyeColor::getName).toList());
 +                list.add("reset");
 +                list.add("disable");
-+                return LeavesCommandUtil.getListMatchingLast(sender, args, list, "", "bukkit.command.leaves");
++                return LeavesCommandUtil.getListMatchingLast(sender, args, list);
 +            }
 +
 +            case 2 -> {
 +                if (DyeColor.byName(args[0], null) != null) {
-+                    return LeavesCommandUtil.getListMatchingLast(sender, args, List.of("reset", "realtime"), "", "bukkit.command.leaves");
++                    return LeavesCommandUtil.getListMatchingLast(sender, args, "reset", "realtime");
 +                }
 +            }
 +        }

--- a/patches/server/0099-Wool-Hopper-Counter.patch
+++ b/patches/server/0099-Wool-Hopper-Counter.patch
@@ -62,10 +62,10 @@ index cee74a6c47cd56a17a8faf68405fee09d6fd4655..9cc932fb547686db7c06f7ef29e3b07b
          if (inventory instanceof WorldlyContainer iworldinventory) {
              return iworldinventory.getSlotsForFace(side);
 diff --git a/src/main/java/org/leavesmc/leaves/command/LeavesCommand.java b/src/main/java/org/leavesmc/leaves/command/LeavesCommand.java
-index b28ca267a841f33ba18fff5587a6b0e677dc1ea1..f9a1f2d7f319c22178c2254347bcdc15f19badd9 100644
+index 92a8c3e4fc400988b3d984e7632a8149a2ce152e..99823283690fcc1e6c0f76d8dcbcca9dfb50470d 100644
 --- a/src/main/java/org/leavesmc/leaves/command/LeavesCommand.java
 +++ b/src/main/java/org/leavesmc/leaves/command/LeavesCommand.java
-@@ -35,6 +35,7 @@ public final class LeavesCommand extends Command {
+@@ -34,6 +34,7 @@ public final class LeavesCommand extends Command {
          commands.put(Set.of("config"), new ConfigCommand());
          commands.put(Set.of("update"), new UpdateCommand());
          commands.put(Set.of("peaceful"), new PeacefulModeSwitchCommand());
@@ -75,13 +75,12 @@ index b28ca267a841f33ba18fff5587a6b0e677dc1ea1..f9a1f2d7f319c22178c2254347bcdc15
              .flatMap(entry -> entry.getKey().stream().map(s -> Map.entry(s, entry.getValue())))
 diff --git a/src/main/java/org/leavesmc/leaves/command/subcommands/CounterCommand.java b/src/main/java/org/leavesmc/leaves/command/subcommands/CounterCommand.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..358780d37600220d132ae8e2e6c594fc71af4e40
+index 0000000000000000000000000000000000000000..8a24409770026450bd1f8e80d006573926b13c58
 --- /dev/null
 +++ b/src/main/java/org/leavesmc/leaves/command/subcommands/CounterCommand.java
 @@ -0,0 +1,121 @@
 +package org.leavesmc.leaves.command.subcommands;
 +
-+import io.papermc.paper.command.CommandUtil;
 +import net.kyori.adventure.text.Component;
 +import net.kyori.adventure.text.JoinConfiguration;
 +import net.kyori.adventure.text.format.NamedTextColor;
@@ -91,6 +90,7 @@ index 0000000000000000000000000000000000000000..358780d37600220d132ae8e2e6c594fc
 +import org.bukkit.command.CommandSender;
 +import org.jetbrains.annotations.NotNull;
 +import org.leavesmc.leaves.LeavesConfig;
++import org.leavesmc.leaves.command.LeavesCommandUtil;
 +import org.leavesmc.leaves.command.LeavesSubcommand;
 +import org.leavesmc.leaves.util.HopperCounter;
 +
@@ -182,12 +182,12 @@ index 0000000000000000000000000000000000000000..358780d37600220d132ae8e2e6c594fc
 +                List<String> list = new ArrayList<>(Arrays.stream(DyeColor.values()).map(DyeColor::getName).toList());
 +                list.add("reset");
 +                list.add("disable");
-+                return CommandUtil.getListMatchingLast(sender, args, list);
++                return LeavesCommandUtil.getListMatchingLast(sender, args, list, "", "bukkit.command.leaves");
 +            }
 +
 +            case 2 -> {
 +                if (DyeColor.byName(args[0], null) != null) {
-+                    return CommandUtil.getListMatchingLast(sender, args, "reset", "realtime");
++                    return LeavesCommandUtil.getListMatchingLast(sender, args, List.of("reset", "realtime"), "", "bukkit.command.leaves");
 +                }
 +            }
 +        }

--- a/patches/server/0100-Leaves-Reload-Command.patch
+++ b/patches/server/0100-Leaves-Reload-Command.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Leaves Reload Command
 
 
 diff --git a/src/main/java/org/leavesmc/leaves/command/LeavesCommand.java b/src/main/java/org/leavesmc/leaves/command/LeavesCommand.java
-index f9a1f2d7f319c22178c2254347bcdc15f19badd9..139c807916ec1be7bf993b34f52343f12eea888a 100644
+index 99823283690fcc1e6c0f76d8dcbcca9dfb50470d..bc8720e3277c011b39d6ed2d06252f2b1abdc31e 100644
 --- a/src/main/java/org/leavesmc/leaves/command/LeavesCommand.java
 +++ b/src/main/java/org/leavesmc/leaves/command/LeavesCommand.java
-@@ -36,6 +36,7 @@ public final class LeavesCommand extends Command {
+@@ -35,6 +35,7 @@ public final class LeavesCommand extends Command {
          commands.put(Set.of("update"), new UpdateCommand());
          commands.put(Set.of("peaceful"), new PeacefulModeSwitchCommand());
          commands.put(Set.of("counter"), new CounterCommand());


### PR DESCRIPTION
问题有点多 paper的Util只检查自己的命令权限 因此部分其它Leaves的命令应该也有这个问题


节选自 `io.papermc.paper.command.CommandUtil`
```java

while (iterator.hasNext()) {
    String s1 = (String) iterator.next();

    if (matches(last, s1) && (sender.hasPermission(PaperCommand.BASE_PERM + s1) || sender.hasPermission("bukkit.command.paper"))) {
        results.add(s1);
    }
}
```