### PR TITLE
Fix action argument check(#353)

### DIFF
--- a/patches/server/0010-Fakeplayer-support.patch
+++ b/patches/server/0010-Fakeplayer-support.patch
@@ -626,10 +626,10 @@ index 4632eb883e9f5efde520ee543bcad25827c0da2c..d710803137a325f34e0628405d5ddfd0
              return event;
 diff --git a/src/main/java/org/leavesmc/leaves/bot/BotCommand.java b/src/main/java/org/leavesmc/leaves/bot/BotCommand.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..789ad3dd37baf80ac5597a37464cbbaceeb55d70
+index 0000000000000000000000000000000000000000..1f8ce23483ba5220043a9c9d7eb857572c9fb8d2
 --- /dev/null
 +++ b/src/main/java/org/leavesmc/leaves/bot/BotCommand.java
-@@ -0,0 +1,543 @@
+@@ -0,0 +1,544 @@
 +package org.leavesmc.leaves.bot;
 +
 +import net.kyori.adventure.text.Component;
@@ -1022,7 +1022,8 @@ index 0000000000000000000000000000000000000000..789ad3dd37baf80ac5597a37464cbbac
 +                newAction = action.create();
 +                newAction.loadCommand(player.getHandle(), action.getArgument().parse(0, realArgs));
 +            }
-+        } catch (IllegalArgumentException ignore) {
++        } catch (IllegalArgumentException e) {
++            newAction = null;
 +        }
 +
 +        if (newAction == null) {


### PR DESCRIPTION
还是抽象问题

原有的代码:
```java
        BotAction<?> newAction = null;
        try {
            if (action instanceof CraftCustomBotAction customBotAction) {
                newAction = customBotAction.createCraft(player, realArgs);
            } else {
                newAction = action.create();
                newAction.loadCommand(player.getHandle(), action.getArgument().parse(0, realArgs));
            }
        } catch (IllegalArgumentException ignored) {
        }

        if (newAction == null) {
            sender.sendMessage(text("Action create error, please check your arguments", NamedTextColor.RED));
            return;
        }
```

错误的参数会导致`Action#loadCommand`报错 但此时`newAction`已经被赋了一个空的Action 绕过了下面的空检查 在`Action#doTick`时疯狂报错

