### PR TITLE
Fix Incorrect Collision Behavior for Block Shape (#344)

### DIFF
--- a/patches/server/0134-Fix-Incorrect-Collision-Behavior-for-Block-Shape.patch
+++ b/patches/server/0134-Fix-Incorrect-Collision-Behavior-for-Block-Shape.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Fortern <blueten.ki@gmail.com>
+Date: Thu, 24 Oct 2024 23:10:34 +0800
+Subject: [PATCH] Fix Incorrect Collision Behavior for Block Shape
+
+
+diff --git a/src/main/java/ca/spottedleaf/moonrise/patches/collisions/CollisionUtil.java b/src/main/java/ca/spottedleaf/moonrise/patches/collisions/CollisionUtil.java
+index 748ab4d637ce463272bae4fdbab6842a27385126..1de40570caed06942d6aba638ee4fa1acb2ecfd1 100644
+--- a/src/main/java/ca/spottedleaf/moonrise/patches/collisions/CollisionUtil.java
++++ b/src/main/java/ca/spottedleaf/moonrise/patches/collisions/CollisionUtil.java
+@@ -56,6 +56,14 @@ public final class CollisionUtil {
+                (box1.minZ - box2.maxZ) < -COLLISION_EPSILON && (box1.maxZ - box2.minZ) > COLLISION_EPSILON;
+     }
+ 
++    // Leaves start
++    public static boolean voxelShapeIntersectVanilla(final net.minecraft.world.phys.AABB box1, final net.minecraft.world.phys.AABB box2) {
++        return box1.minX < box2.maxX && box1.maxX > box2.minX &&
++               box1.minY < box2.maxY && box1.maxY > box2.minY &&
++               box1.minZ < box2.maxZ && box1.maxZ > box2.minZ;
++    }
++    // Leaves end
++
+     // assume !isEmpty(target) && abs(source_move) >= COLLISION_EPSILON
+     public static double collideX(final net.minecraft.world.phys.AABB target, final net.minecraft.world.phys.AABB source, final double source_move) {
+         if ((source.minY - target.maxY) < -COLLISION_EPSILON && (source.maxY - target.minY) > COLLISION_EPSILON &&
+@@ -1700,7 +1708,10 @@ public final class CollisionUtil {
+                                     net.minecraft.world.phys.AABB singleAABB = ((ca.spottedleaf.moonrise.patches.collisions.shape.CollisionVoxelShape)blockCollision).moonrise$getSingleAABBRepresentation();
+                                     if (singleAABB != null) {
+                                         singleAABB = singleAABB.move((double)blockX, (double)blockY, (double)blockZ);
+-                                        if (!voxelShapeIntersect(aabb, singleAABB)) {
++                                        // Leaves start - Fix incorrect collision behavior for block shape
++                                        boolean isBlockShape = blockCollision == net.minecraft.world.phys.shapes.Shapes.block();
++                                        if (isBlockShape && !voxelShapeIntersectVanilla(aabb, singleAABB) || !isBlockShape && !voxelShapeIntersect(aabb, singleAABB)) {
++                                        // Leaves end - Fix incorrect collision behavior for block shape
+                                             continue;
+                                         }
+ 


### PR DESCRIPTION
修复了Paper特殊的碰撞检测，该问题导致某些情况下实体会移动到方块内部。