### PR TITLE
[ci skip]update contributing and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ maven {
 }
 
 dependencies {
-    compileOnly("org.leavesmc.leaves:leaves-api:1.21-R0.1-SNAPSHOT")
+    compileOnly("org.leavesmc.leaves:leaves-api:1.21.1-R0.1-SNAPSHOT")
 }
  ```
 
@@ -40,7 +40,7 @@ Each time you want to update your dependency, you must re-build Leaves.
 Leaves-Server:
 ```kotlin
 dependencies {
-    compileOnly("org.leavesmc.leaves:leaves:1.21-R0.1-SNAPSHOT")
+    compileOnly("org.leavesmc.leaves:leaves:1.21.1-R0.1-SNAPSHOT")
 }
  ```
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -1,7 +1,7 @@
 Leaves
 ===========
 
-[![Leaves CI](https://github.com/LeavesMC/Leaves/actions/workflows/leaves.yml/badge.svg)](https://github.com/LeavesMC/Leaves/actions/workflows/leaves.yml)
+[![Leaves CI](https://github.com/LeavesMC/Leaves/actions/workflows/build.yml/badge.svg)](https://github.com/LeavesMC/Leaves/actions/workflows/leaves.yml)
 [![Leaves Download](https://img.shields.io/github/downloads/LeavesMC/Leaves/total?color=0&logo=github)](https://github.com/LeavesMC/Leaves/releases/latest)
 [![Discord](https://badgen.net/discord/online-members/5hgtU72w33?icon=discord&label=Discord&list=what)](https://discord.gg/5hgtU72w33)
 [![QQ](https://img.shields.io/badge/QQ_Unofficial-815857713-blue)](http://qm.qq.com/cgi-bin/qm/qr?_wv=1027&k=nisbmnCFeEJCcYWBQ10th4Fu99XWklH4&authKey=8VlUxSdrFCIwmIpxFQIGR8%2BXvIQ2II%2Bx2JfxuQ8amr9UKgINh%2BdXjudQfc%2FIeTO5&noverify=0&group_code=815857713)
@@ -30,7 +30,7 @@ maven {
 }
 
 dependencies {
-    compileOnly("org.leavesmc.leaves:leaves-api:1.21-R0.1-SNAPSHOT")
+    compileOnly("org.leavesmc.leaves:leaves-api:1.21.1-R0.1-SNAPSHOT")
 }
  ```
 
@@ -39,7 +39,7 @@ dependencies {
 Leaves-Server:
 ```kotlin
 dependencies {
-    compileOnly("org.leavesmc.leaves:leaves:1.21R0.1-SNAPSHOT")
+    compileOnly("org.leavesmc.leaves:leaves:1.21.1-R0.1-SNAPSHOT")
 }
  ```
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -23,8 +23,8 @@ See also [This issue](https://github.com/isaacs/github/issues/1681), and then yo
 Before coding, you need these softwares / tools as Dev Environment.
 
 - `git`
-- `JDK 17 or higher`
-  - We used Gradle's toolchains, so you can build Leaves using JRE 8. (When Gradle can't find JDK 17, it will download it automatically.)
+- `JDK 21 or higher`
+  - We used Gradle's toolchains, so you can build Leaves using JRE 8. (When Gradle can't find JDK 21, it will download it automatically.)
 
 If you're using Windows Operating System, you can use `WSL` to speed up building.
 

--- a/docs/CONTRIBUTING_cn.md
+++ b/docs/CONTRIBUTING_cn.md
@@ -21,8 +21,8 @@ Contributing to Leaves
 在开始开发之前，您首先需要拥有以下软件作为开发环境：
 
 - `git`
-- `JDK 17 或更高版本`
-  - 我们使用了 Gradle 的工具链，这让你可以使用 JRE 8 就进行构建。(Gradle 在找不到 JDK 17 时会自动下载)
+- `JDK 21 或更高版本`
+  - 我们使用了 Gradle 的工具链，这让你可以使用 JRE 8 就进行构建。(Gradle 在找不到 JDK 21 时会自动下载)
 
 如果你使用 Windows 系统进行开发，那么你可以使用 `WSL` 来加速构建。
 


### PR DESCRIPTION
* 调整贡献页面，将最低使用的 JDK 版本从 17 调整到 21
* 修复中文 readme 页面 Leaves CI 图标未正确显示的问题
* 将 readme 中的示例版本从 1.21 调整到 1.21.1（顺带修复了中文版的一个小问题）