### PR TITLE
Support chatimage protocol

### DIFF
--- a/leaves-server/minecraft-patches/features/0118-Vanilla-player-display-name.patch
+++ b/leaves-server/minecraft-patches/features/0118-Vanilla-player-display-name.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Lumine1909 <133463833+Lumine1909@users.noreply.github.com>
+Date: Sun, 30 Mar 2025 21:53:45 +0800
+Subject: [PATCH] Vanilla player display name
+
+
+diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
+index eba1717566a8ea534bbf149e0593cc7656df2db9..311d4abc9cbd99e6b03135dadbd8ee93e7bc4a48 100644
+--- a/net/minecraft/server/level/ServerPlayer.java
++++ b/net/minecraft/server/level/ServerPlayer.java
+@@ -449,7 +449,7 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc
+ 
+         // CraftBukkit start
+         this.displayName = this.getScoreboardName();
+-        this.adventure$displayName = net.kyori.adventure.text.Component.text(this.getScoreboardName()); // Paper
++        this.adventure$displayName = org.leavesmc.leaves.LeavesConfig.fix.vanillaDisplayName ? io.papermc.paper.adventure.PaperAdventure.asAdventure(this.getDisplayName()) : net.kyori.adventure.text.Component.text(this.getScoreboardName()); // Paper // Leaves - Vanilla display name
+         this.bukkitPickUpLoot = true;
+         this.maxHealthCache = this.getMaxHealth();
+     }

--- a/leaves-server/src/main/java/org/leavesmc/leaves/LeavesConfig.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/LeavesConfig.java
@@ -844,6 +844,9 @@ public final class LeavesConfig {
         @GlobalConfig("rei-server-protocol")
         public boolean reiServerProtocol = false;
 
+        @GlobalConfig("chat-image-protocol")
+        public boolean chatImageProtocol = false;
+
         @GlobalConfig("recipe-send-all")
         public boolean recipeSendAll = false;
     }
@@ -1031,6 +1034,9 @@ public final class LeavesConfig {
     public static class FixConfig {
         @GlobalConfig("vanilla-hopper")
         public boolean vanillaHopper = false;
+
+        @GlobalConfig("vanilla-display-name")
+        public boolean vanillaDisplayName = false;
 
         @RemovedConfig(name = "spigot-EndPlatform-destroy", category = "fix")
         private final boolean spigotEndPlatformDestroy = false;

--- a/leaves-server/src/main/java/org/leavesmc/leaves/protocol/chatimage/ChatImageIndex.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/protocol/chatimage/ChatImageIndex.java
@@ -1,0 +1,16 @@
+package org.leavesmc.leaves.protocol.chatimage;
+
+public class ChatImageIndex {
+
+    public int index;
+    public int total;
+    public String url;
+    public String bytes;
+
+    public ChatImageIndex(int index, int total, String url, String bytes) {
+        this.index = index;
+        this.total = total;
+        this.url = url;
+        this.bytes = bytes;
+    }
+}

--- a/leaves-server/src/main/java/org/leavesmc/leaves/protocol/chatimage/ChatImageIndex.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/protocol/chatimage/ChatImageIndex.java
@@ -1,5 +1,8 @@
 package org.leavesmc.leaves.protocol.chatimage;
 
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+
 public class ChatImageIndex {
 
     public int index;

--- a/leaves-server/src/main/java/org/leavesmc/leaves/protocol/chatimage/ChatImageIndex.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/protocol/chatimage/ChatImageIndex.java
@@ -1,8 +1,5 @@
 package org.leavesmc.leaves.protocol.chatimage;
 
-import com.mojang.serialization.Codec;
-import com.mojang.serialization.codecs.RecordCodecBuilder;
-
 public class ChatImageIndex {
 
     public int index;

--- a/leaves-server/src/main/java/org/leavesmc/leaves/protocol/chatimage/ChatImageProtocol.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/protocol/chatimage/ChatImageProtocol.java
@@ -46,7 +46,9 @@ public class ChatImageProtocol {
         }
         for (UUID uuid : names) {
             ServerPlayer serverPlayer = server.getPlayerList().getPlayer(uuid);
-            ProtocolUtils.sendPayloadPacket(serverPlayer, new FileInfoChannelPayload("true->" + title.url));
+            if (serverPlayer != null) {
+                ProtocolUtils.sendPayloadPacket(serverPlayer, new FileInfoChannelPayload("true->" + title.url));
+            }
         }
     }
 

--- a/leaves-server/src/main/java/org/leavesmc/leaves/protocol/chatimage/ChatImageProtocol.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/protocol/chatimage/ChatImageProtocol.java
@@ -40,12 +40,12 @@ public class ChatImageProtocol {
         if (title.total != blocks.size()) {
             return;
         }
-        List<String> names = SERVER_BLOCK_CACHE.getUsers(title.url);
+        List<UUID> names = SERVER_BLOCK_CACHE.getUsers(title.url);
         if (names == null || player == null) {
             return;
         }
-        for (String uuid : names) {
-            ServerPlayer serverPlayer = server.getPlayerList().getPlayer(UUID.fromString(uuid));
+        for (UUID uuid : names) {
+            ServerPlayer serverPlayer = server.getPlayerList().getPlayer(uuid);
             ProtocolUtils.sendPayloadPacket(serverPlayer, new FileInfoChannelPayload("true->" + title.url));
         }
     }
@@ -60,7 +60,7 @@ public class ChatImageProtocol {
         Map<Integer, String> list = SERVER_BLOCK_CACHE.getBlock(url);
         if (list == null) {
             ProtocolUtils.sendPayloadPacket(player, new FileInfoChannelPayload("null->" + url));
-            SERVER_BLOCK_CACHE.tryAddUser(url, player.getStringUUID());
+            SERVER_BLOCK_CACHE.tryAddUser(url, player.getUUID());
             return;
         }
         for (Map.Entry<Integer, String> entry : list.entrySet()) {

--- a/leaves-server/src/main/java/org/leavesmc/leaves/protocol/chatimage/ChatImageProtocol.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/protocol/chatimage/ChatImageProtocol.java
@@ -1,0 +1,70 @@
+package org.leavesmc.leaves.protocol.chatimage;
+
+import com.google.gson.Gson;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerPlayer;
+import org.jetbrains.annotations.Contract;
+import org.leavesmc.leaves.LeavesConfig;
+import org.leavesmc.leaves.protocol.core.LeavesProtocol;
+import org.leavesmc.leaves.protocol.core.ProtocolHandler;
+import org.leavesmc.leaves.protocol.core.ProtocolUtils;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.leavesmc.leaves.protocol.chatimage.ServerBlockCache.SERVER_BLOCK_CACHE;
+
+@LeavesProtocol(namespace = "chatimage")
+public class ChatImageProtocol {
+
+    public static final String PROTOCOL_ID = "chatimage";
+    public static final Gson gson = new Gson();
+
+    @Contract("_ -> new")
+    public static ResourceLocation id(String path) {
+        return ResourceLocation.tryBuild(PROTOCOL_ID, path);
+    }
+
+    @ProtocolHandler.PayloadReceiver(payload = FileChannelPayload.class, payloadId = "get_file_channel")
+    public static void serverFileChannelReceived(ServerPlayer player, FileChannelPayload payload) {
+        if (!LeavesConfig.protocol.chatImageProtocol) {
+            return;
+        }
+
+        MinecraftServer server = MinecraftServer.getServer();
+        String res = payload.message();
+        ChatImageIndex title = gson.fromJson(res, ChatImageIndex.class);
+        Map<Integer, String> blocks = SERVER_BLOCK_CACHE.createBlock(title, res);
+        if (title.total != blocks.size()) {
+            return;
+        }
+        List<String> names = SERVER_BLOCK_CACHE.getUsers(title.url);
+        if (names == null || player == null) {
+            return;
+        }
+        for (String uuid : names) {
+            ServerPlayer serverPlayer = server.getPlayerList().getPlayer(UUID.fromString(uuid));
+            ProtocolUtils.sendPayloadPacket(serverPlayer, new FileInfoChannelPayload("true->" + title.url));
+        }
+    }
+
+    @ProtocolHandler.PayloadReceiver(payload = FileInfoChannelPayload.class, payloadId = "file_info")
+    public static void serverGetFileChannelReceived(ServerPlayer player, FileInfoChannelPayload packet) {
+        if (!LeavesConfig.protocol.chatImageProtocol) {
+            return;
+        }
+
+        String url = packet.message();
+        Map<Integer, String> list = SERVER_BLOCK_CACHE.getBlock(url);
+        if (list == null) {
+            ProtocolUtils.sendPayloadPacket(player, new FileInfoChannelPayload("null->" + url));
+            SERVER_BLOCK_CACHE.tryAddUser(url, player.getStringUUID());
+            return;
+        }
+        for (Map.Entry<Integer, String> entry : list.entrySet()) {
+            ProtocolUtils.sendPayloadPacket(player, new DownloadFileChannelPayload(entry.getValue()));
+        }
+    }
+}

--- a/leaves-server/src/main/java/org/leavesmc/leaves/protocol/chatimage/DownloadFileChannelPayload.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/protocol/chatimage/DownloadFileChannelPayload.java
@@ -1,0 +1,32 @@
+package org.leavesmc.leaves.protocol.chatimage;
+
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.resources.ResourceLocation;
+import org.leavesmc.leaves.protocol.core.LeavesCustomPayload;
+import org.leavesmc.leaves.protocol.core.ProtocolUtils;
+
+public record DownloadFileChannelPayload(String message) implements LeavesCustomPayload<DownloadFileChannelPayload> {
+
+    private static final ResourceLocation ID = ChatImageProtocol.id("download_file_channel");
+
+    private static final StreamCodec<RegistryFriendlyByteBuf, DownloadFileChannelPayload> CODEC =
+        StreamCodec.composite(ByteBufCodecs.STRING_UTF8, DownloadFileChannelPayload::message, DownloadFileChannelPayload::new);
+
+    @Override
+    public void write(FriendlyByteBuf buf) {
+        CODEC.encode(ProtocolUtils.decorate(buf), this);
+    }
+
+    @Override
+    public ResourceLocation id() {
+        return ID;
+    }
+
+    @New
+    public static DownloadFileChannelPayload create(ResourceLocation location, FriendlyByteBuf buf) {
+        return CODEC.decode(ProtocolUtils.decorate(buf));
+    }
+}

--- a/leaves-server/src/main/java/org/leavesmc/leaves/protocol/chatimage/FileChannelPayload.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/protocol/chatimage/FileChannelPayload.java
@@ -1,0 +1,32 @@
+package org.leavesmc.leaves.protocol.chatimage;
+
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.resources.ResourceLocation;
+import org.leavesmc.leaves.protocol.core.LeavesCustomPayload;
+import org.leavesmc.leaves.protocol.core.ProtocolUtils;
+
+public record FileChannelPayload(String message) implements LeavesCustomPayload<FileChannelPayload> {
+
+    private static final ResourceLocation ID = ChatImageProtocol.id("get_file_channel");
+
+    private static final StreamCodec<RegistryFriendlyByteBuf, FileChannelPayload> CODEC =
+        StreamCodec.composite(ByteBufCodecs.STRING_UTF8, FileChannelPayload::message, FileChannelPayload::new);
+
+    @Override
+    public void write(FriendlyByteBuf buf) {
+        CODEC.encode(ProtocolUtils.decorate(buf), this);
+    }
+
+    @Override
+    public ResourceLocation id() {
+        return ID;
+    }
+
+    @New
+    public static FileChannelPayload create(ResourceLocation location, FriendlyByteBuf buf) {
+        return CODEC.decode(ProtocolUtils.decorate(buf));
+    }
+}

--- a/leaves-server/src/main/java/org/leavesmc/leaves/protocol/chatimage/FileInfoChannelPayload.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/protocol/chatimage/FileInfoChannelPayload.java
@@ -1,0 +1,32 @@
+package org.leavesmc.leaves.protocol.chatimage;
+
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.resources.ResourceLocation;
+import org.leavesmc.leaves.protocol.core.LeavesCustomPayload;
+import org.leavesmc.leaves.protocol.core.ProtocolUtils;
+
+public record FileInfoChannelPayload(String message) implements LeavesCustomPayload<FileInfoChannelPayload> {
+
+    private static final ResourceLocation ID = ChatImageProtocol.id("file_info");
+
+    private static final StreamCodec<RegistryFriendlyByteBuf, FileInfoChannelPayload> CODEC =
+        StreamCodec.composite(ByteBufCodecs.STRING_UTF8, FileInfoChannelPayload::message, FileInfoChannelPayload::new);
+
+    @Override
+    public void write(FriendlyByteBuf buf) {
+        CODEC.encode(ProtocolUtils.decorate(buf), this);
+    }
+
+    @Override
+    public ResourceLocation id() {
+        return ID;
+    }
+
+    @New
+    public static FileInfoChannelPayload create(ResourceLocation location, FriendlyByteBuf buf) {
+        return CODEC.decode(ProtocolUtils.decorate(buf));
+    }
+}

--- a/leaves-server/src/main/java/org/leavesmc/leaves/protocol/chatimage/ServerBlockCache.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/protocol/chatimage/ServerBlockCache.java
@@ -8,13 +8,14 @@ import org.leavesmc.leaves.LeavesLogger;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 public class ServerBlockCache {
 
     public static final ServerBlockCache SERVER_BLOCK_CACHE = new ServerBlockCache();
 
-    public Cache<String, List<String>> userCache = CacheBuilder.newBuilder().expireAfterAccess(60, TimeUnit.SECONDS).build();
+    public Cache<String, List<UUID>> userCache = CacheBuilder.newBuilder().expireAfterAccess(60, TimeUnit.SECONDS).build();
     public Cache<String, Map<Integer, String>> blockCache = CacheBuilder.newBuilder().expireAfterAccess(60, TimeUnit.SECONDS).build();
     public Cache<String, Integer> fileCount = CacheBuilder.newBuilder().expireAfterAccess(60, TimeUnit.SECONDS).build();
 
@@ -42,9 +43,9 @@ public class ServerBlockCache {
         return null;
     }
 
-    public void tryAddUser(String url, String uuid) {
+    public void tryAddUser(String url, UUID uuid) {
         try {
-            List<String> names = this.userCache.get(url, Lists::newArrayList);
+            List<UUID> names = this.userCache.get(url, Lists::newArrayList);
             names.add(uuid);
             this.userCache.put(url, names);
         } catch (Exception e) {
@@ -52,8 +53,8 @@ public class ServerBlockCache {
         }
     }
 
-    public List<String> getUsers(String url) {
-        List<String> names;
+    public List<UUID> getUsers(String url) {
+        List<UUID> names;
         if ((names = this.userCache.getIfPresent(url)) != null) {
             this.userCache.put(url, Lists.newArrayList());
             return names;

--- a/leaves-server/src/main/java/org/leavesmc/leaves/protocol/chatimage/ServerBlockCache.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/protocol/chatimage/ServerBlockCache.java
@@ -15,16 +15,12 @@ public class ServerBlockCache {
     public static final ServerBlockCache SERVER_BLOCK_CACHE = new ServerBlockCache();
 
     public Cache<String, List<String>> userCache = CacheBuilder.newBuilder().expireAfterAccess(60, TimeUnit.SECONDS).build();
-    public Cache<String, Long> blockCacheTime = CacheBuilder.newBuilder().expireAfterAccess(60, TimeUnit.SECONDS).build();
     public Cache<String, Map<Integer, String>> blockCache = CacheBuilder.newBuilder().expireAfterAccess(60, TimeUnit.SECONDS).build();
     public Cache<String, Integer> fileCount = CacheBuilder.newBuilder().expireAfterAccess(60, TimeUnit.SECONDS).build();
 
     public Map<Integer, String> createBlock(ChatImageIndex title, String imgBytes) {
         try {
             Map<Integer, String> blocks = this.blockCache.get(title.url, HashMap::new);
-            if (blocks.isEmpty()) {
-                this.blockCacheTime.put(title.url, System.currentTimeMillis());
-            }
             blocks.put(title.index, imgBytes);
             this.blockCache.put(title.url, blocks);
             this.fileCount.put(title.url, title.total);

--- a/leaves-server/src/main/java/org/leavesmc/leaves/protocol/chatimage/ServerBlockCache.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/protocol/chatimage/ServerBlockCache.java
@@ -1,0 +1,68 @@
+package org.leavesmc.leaves.protocol.chatimage;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.collect.Lists;
+import org.leavesmc.leaves.LeavesLogger;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+public class ServerBlockCache {
+
+    public static final ServerBlockCache SERVER_BLOCK_CACHE = new ServerBlockCache();
+
+    public Cache<String, List<String>> userCache = CacheBuilder.newBuilder().expireAfterAccess(60, TimeUnit.SECONDS).build();
+    public Cache<String, Long> blockCacheTime = CacheBuilder.newBuilder().expireAfterAccess(60, TimeUnit.SECONDS).build();
+    public Cache<String, Map<Integer, String>> blockCache = CacheBuilder.newBuilder().expireAfterAccess(60, TimeUnit.SECONDS).build();
+    public Cache<String, Integer> fileCount = CacheBuilder.newBuilder().expireAfterAccess(60, TimeUnit.SECONDS).build();
+
+    public Map<Integer, String> createBlock(ChatImageIndex title, String imgBytes) {
+        try {
+            Map<Integer, String> blocks = this.blockCache.get(title.url, HashMap::new);
+            if (blocks.isEmpty()) {
+                this.blockCacheTime.put(title.url, System.currentTimeMillis());
+            }
+            blocks.put(title.index, imgBytes);
+            this.blockCache.put(title.url, blocks);
+            this.fileCount.put(title.url, title.total);
+            return blocks;
+        } catch (Exception e) {
+            LeavesLogger.LOGGER.warning("Failed to create block for title " + title.url + ": " + e);
+            return null;
+        }
+    }
+
+    public Map<Integer, String> getBlock(String url) {
+        Map<Integer, String> list;
+        Integer total;
+        if ((list = this.blockCache.getIfPresent(url)) != null && (total = this.fileCount.getIfPresent(url)) != null) {
+            if (total == list.size()) {
+                return list;
+            }
+        }
+        return null;
+    }
+
+    public void tryAddUser(String url, String uuid) {
+        try {
+            List<String> names = this.userCache.get(url, Lists::newArrayList);
+            names.add(uuid);
+            this.userCache.put(url, names);
+        } catch (Exception e) {
+            LeavesLogger.LOGGER.warning("Failed to add user " + uuid + ": " + e);
+        }
+    }
+
+    public List<String> getUsers(String url) {
+        List<String> names;
+        if ((names = this.userCache.getIfPresent(url)) != null) {
+            this.userCache.put(url, Lists.newArrayList());
+            return names;
+        } else {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
协议部分很简单 但是由于作者和Paper的一些奇奇怪怪的代码 需要开启这个新的配置项才能使用 并且可能与某些现有的聊天插件冲突

原因解析：

![image](https://github.com/user-attachments/assets/e847cc39-ee92-4c66-b272-8a862e8c61cd)

这个mod会在收到聊天并解析时处理发送的玩家 而原版的玩家名会被解析为`MutableComponent`（如果你曾经把鼠标放到过玩家名上会发现有悬浮字）

而Paper的Adventure处理的方法是直接把玩家的 String name变成 adventure component ，这会导致玩家名和聊天内容一起被解析为 String，mod无法处理消息

因此在Paper及其下游会出现
```
[21:43:46] [Render thread/WARN]: 识别失败:class java.lang.String cannot be cast to class net.minecraft.class_2561 (java.lang.String is in module java.base of loader 'bootstrap'; net.minecraft.class_2561 is in unnamed module of loader 'knot' @604ed9f0)
```


（我在考虑要不要给Paper或Chatimage发pr处理这个问题