### PR TITLE
Fix #492

### DIFF
--- a/leaves-server/minecraft-patches/features/0123-Fix-chunk-reload-detector.patch
+++ b/leaves-server/minecraft-patches/features/0123-Fix-chunk-reload-detector.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MC_XiaoHei <xiaohei.xor7@outlook.com>
+Date: Sat, 17 May 2025 03:01:48 +0000
+Subject: [PATCH] Fix chunk reload detector
+
+
+diff --git a/net/minecraft/server/level/ServerEntity.java b/net/minecraft/server/level/ServerEntity.java
+index 7681195587d361acf524d09ad3958e628aad73b6..c768a653a4a9c62e1db952979fca0e6176aa3849 100644
+--- a/net/minecraft/server/level/ServerEntity.java
++++ b/net/minecraft/server/level/ServerEntity.java
+@@ -396,7 +396,7 @@ public class ServerEntity {
+             if (!list.isEmpty()) {
+                 consumer.accept(new ClientboundSetEquipmentPacket(this.entity.getId(), list, true)); // Paper - data sanitization
+             }
+-            ((LivingEntity) this.entity).detectEquipmentUpdates(); // CraftBukkit - SPIGOT-3789: sync again immediately after sending
++            // ((LivingEntity) this.entity).detectEquipmentUpdates(); // CraftBukkit - SPIGOT-3789: sync again immediately after sending // Leaves - fix chunk reload detector (#492)
+         }
+ 
+         if (!this.entity.getPassengers().isEmpty()) {


### PR DESCRIPTION
已经过测试，机器功能恢复正常。
删除后果：当插件生成生物同时修改手中物品为空的时候会出现显示问题。使用回调可以避免
有问题的代码：
```java
LivingEntity entity = (LivingEntity)player.getWorld().spawnEntity(up, EntityType.valueOf("VEX"));
entity.getEquipment().setItemInMainHand(null);
// or
entity.getEquipment().setItemInMainHand(new ItemStack(Material.AIR));
```
可用的代码：
```java
Vex vex = e.getPlayer().getWorld().spawn(up, Vex.class, (entity) -> {
    entity.getEquipment().setItemInMainHand(null);
    // or
    entity.getEquipment().setItemInMainHand(new ItemStack(Material.AIR));
});
```
当且仅当修改为空时才有问题。