### PR TITLE
New protocol core start

### DIFF
--- a/leaves-server/minecraft-patches/features/0004-Leaves-Protocol-Core.patch
+++ b/leaves-server/minecraft-patches/features/0004-Leaves-Protocol-Core.patch
@@ -5,17 +5,16 @@ Subject: [PATCH] Leaves Protocol Core
 
 
 diff --git a/net/minecraft/network/protocol/common/custom/CustomPacketPayload.java b/net/minecraft/network/protocol/common/custom/CustomPacketPayload.java
-index fb263fa1f30a7dfcb7ec2656abfb38e5fe88eac9..7e19dfe90a63ff26f03b95891dacb7360bba5a3c 100644
+index fb263fa1f30a7dfcb7ec2656abfb38e5fe88eac9..d7d13b4048f1d21491c2b5269433855558276272 100644
 --- a/net/minecraft/network/protocol/common/custom/CustomPacketPayload.java
 +++ b/net/minecraft/network/protocol/common/custom/CustomPacketPayload.java
-@@ -40,13 +40,23 @@ public interface CustomPacketPayload {
+@@ -40,13 +40,22 @@ public interface CustomPacketPayload {
  
              @Override
              public void encode(B buffer, CustomPacketPayload value) {
 +                // Leaves start - protocol core
 +                if (value instanceof org.leavesmc.leaves.protocol.core.LeavesCustomPayload<?> payload) {
-+                    buffer.writeResourceLocation(payload.id());
-+                    payload.write(buffer);
++                    org.leavesmc.leaves.protocol.core.LeavesProtocolManager.encode(buffer, payload);
 +                    return;
 +                }
 +                // Leaves end - protocol core
@@ -34,23 +33,28 @@ index fb263fa1f30a7dfcb7ec2656abfb38e5fe88eac9..7e19dfe90a63ff26f03b95891dacb736
          };
      }
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index 4e5b27f2d00a6be6da6db461471395a515dc9b38..5b72b9104ca26f9e0d43045b5cd9101af4399f64 100644
+index 4e5b27f2d00a6be6da6db461471395a515dc9b38..12cc30fe127fabbb6ed7c6f677242033359e6e85 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
-@@ -1742,6 +1742,8 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1742,6 +1742,13 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
          profilerFiller.popPush("server gui refresh");
  
++<<<<<<< Updated upstream
 +        org.leavesmc.leaves.protocol.core.LeavesProtocolManager.handleTick(); // Leaves - protocol
++=======
++        org.leavesmc.leaves.protocol.core.LeavesProtocolManager.handleTick(tickCount); // Leaves - protocol
++        org.leavesmc.leaves.util.BreakBedrockList.endTick(); // Leaves - break bedrock list
++>>>>>>> Stashed changes
 +
          for (int i = 0; i < this.tickables.size(); i++) {
              this.tickables.get(i).run();
          }
 diff --git a/net/minecraft/server/network/ServerCommonPacketListenerImpl.java b/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
-index d385cb836b7713f2dbd0b8693777c8e5ea0a74e4..150905d75f46fa9d9c7fbb7a7647fba9816416da 100644
+index 186393485396cfe9b1baef29586198356e2d2600..93cb28552f25c89ef3a5e705c66708b67c95c0af 100644
 --- a/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
 +++ b/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
-@@ -136,6 +136,12 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+@@ -136,6 +136,15 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
  
      @Override
      public void handleCustomPayload(ServerboundCustomPayloadPacket packet) {
@@ -58,12 +62,15 @@ index d385cb836b7713f2dbd0b8693777c8e5ea0a74e4..150905d75f46fa9d9c7fbb7a7647fba9
 +        if (packet.payload() instanceof org.leavesmc.leaves.protocol.core.LeavesCustomPayload<?> leavesPayload) {
 +            org.leavesmc.leaves.protocol.core.LeavesProtocolManager.handlePayload(player, leavesPayload);
 +        }
++        if (packet.payload() instanceof net.minecraft.network.protocol.common.custom.DiscardedPayload(net.minecraft.resources.ResourceLocation id, byte[] data)) {
++            org.leavesmc.leaves.protocol.core.LeavesProtocolManager.handleBytebuf(player, id, io.netty.buffer.Unpooled.wrappedBuffer(data));
++        }
 +        // Leaves end - protocol
 +
          // Paper start
          if (packet.payload() instanceof net.minecraft.network.protocol.common.custom.BrandPayload(String brand)) {
              this.player.clientBrandName = brand;
-@@ -189,6 +195,7 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+@@ -189,6 +198,7 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
          final String channel = new String(data, from, length, java.nio.charset.StandardCharsets.US_ASCII);
          if (register) {
              this.getCraftPlayer().addChannel(channel);
@@ -72,7 +79,7 @@ index d385cb836b7713f2dbd0b8693777c8e5ea0a74e4..150905d75f46fa9d9c7fbb7a7647fba9
              this.getCraftPlayer().removeChannel(channel);
          }
 diff --git a/net/minecraft/server/players/PlayerList.java b/net/minecraft/server/players/PlayerList.java
-index 6e22aedd36add8e39a82248193f324b36dfa27b5..3b1cf63aff568c261479f6ff16ddc22e80f97e8f 100644
+index 9ca3c55a3b5b1a532b86b08eb92460df4cb54f2a..5dea870f75b23bf3300f19945ca7f348001e5ad4 100644
 --- a/net/minecraft/server/players/PlayerList.java
 +++ b/net/minecraft/server/players/PlayerList.java
 @@ -334,6 +334,8 @@ public abstract class PlayerList {

--- a/leaves-server/minecraft-patches/features/0007-Leaves-Fakeplayer.patch
+++ b/leaves-server/minecraft-patches/features/0007-Leaves-Fakeplayer.patch
@@ -30,7 +30,7 @@ index 4ed9611994c5c8da01fede690197527c5b3a5731..364ddf9f25ef3cb97ba788c469fee9dd
      private DisconnectionDetails disconnectionDetails;
      private boolean encrypted;
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index 5b72b9104ca26f9e0d43045b5cd9101af4399f64..940e6cb4b8f990e3c4ae8a5efc7adc56ffae28de 100644
+index 12cc30fe127fabbb6ed7c6f677242033359e6e85..ae635725487bc4a4073ddaedd61124e2ecb31111 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
 @@ -303,6 +303,8 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -59,7 +59,7 @@ index 5b72b9104ca26f9e0d43045b5cd9101af4399f64..940e6cb4b8f990e3c4ae8a5efc7adc56
          // CraftBukkit start
          if (this.server != null) {
              this.server.spark.disable(); // Paper - spark
-@@ -1760,6 +1765,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1765,6 +1770,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
      public void tickConnection() {
          this.getConnection().tick();
@@ -67,7 +67,7 @@ index 5b72b9104ca26f9e0d43045b5cd9101af4399f64..940e6cb4b8f990e3c4ae8a5efc7adc56
      }
  
      private void synchronizeTime(ServerLevel level) {
-@@ -2805,6 +2811,16 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -2810,6 +2816,16 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          return 0;
      }
  

--- a/leaves-server/minecraft-patches/features/0015-No-chat-sign.patch
+++ b/leaves-server/minecraft-patches/features/0015-No-chat-sign.patch
@@ -104,10 +104,10 @@ index e56f26fc504538d88bfa1954e929ee44fd31d657..e4946438d0c1fb9d2be616cb95768f89
      }
  
 diff --git a/net/minecraft/server/network/ServerCommonPacketListenerImpl.java b/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
-index e4a4e943327272d6e9040faa2e3cae7f5f10a211..e484a8c5e82252fb1659939925c72b9195152cae 100644
+index 93cb28552f25c89ef3a5e705c66708b67c95c0af..232fba351b3e840bc33e8b560d4a901a0fabb002 100644
 --- a/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
 +++ b/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
-@@ -288,10 +288,24 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+@@ -291,10 +291,24 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
      }
  
      public void send(Packet<?> packet) {

--- a/leaves-server/minecraft-patches/features/0039-Bedrock-break-list.patch
+++ b/leaves-server/minecraft-patches/features/0039-Bedrock-break-list.patch
@@ -1,18 +1,25 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: violetc <58360096+s-yh-china@users.noreply.github.com>
 Date: Wed, 8 May 2024 22:19:25 +0800
-Subject: [PATCH] Bedrock break list
+Subject: [PATCH]  Bedrock break list
 
+# Conflicts:
+#	net/minecraft/server/MinecraftServer.java
 
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index 5652336b01fc7a1a0eb8a86b2a1d921872d60c2a..7b87939d3f044f4b1d2a8c6492a24ea18855a404 100644
+index b21fc0b8a60f1585188047f62f3d56514f58c709..ca4fdcabbe6c0c57bfa13ef6d83bcd560baae8fc 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
-@@ -1752,6 +1752,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1751,12 +1751,8 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+ 
          profilerFiller.popPush("server gui refresh");
  
-         org.leavesmc.leaves.protocol.core.LeavesProtocolManager.handleTick(); // Leaves - protocol
-+        org.leavesmc.leaves.util.BreakBedrockList.endTick(); // Leaves - break bedrock list
+-<<<<<<< Updated upstream
+-        org.leavesmc.leaves.protocol.core.LeavesProtocolManager.handleTick(); // Leaves - protocol
+-=======
+         org.leavesmc.leaves.protocol.core.LeavesProtocolManager.handleTick(tickCount); // Leaves - protocol
+         org.leavesmc.leaves.util.BreakBedrockList.endTick(); // Leaves - break bedrock list
+->>>>>>> Stashed changes
  
          for (int i = 0; i < this.tickables.size(); i++) {
              this.tickables.get(i).run();

--- a/leaves-server/src/main/java/org/leavesmc/leaves/protocol/BBORProtocol.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/protocol/BBORProtocol.java
@@ -87,7 +87,7 @@ public class BBORProtocol {
         }
     }
 
-    @ProtocolHandler.PayloadReceiver(payload = EmptyPayload.class, payloadId = "subscribe")
+    @ProtocolHandler.PayloadReceiver(payload = EmptyPayload.class, key = "subscribe")
     public static void onPlayerSubscribed(@NotNull ServerPlayer player, EmptyPayload payload) {
         if (LeavesConfig.protocol.bborProtocol) {
             players.put(player.getId(), player);

--- a/leaves-server/src/main/java/org/leavesmc/leaves/protocol/CarpetServerProtocol.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/protocol/CarpetServerProtocol.java
@@ -42,7 +42,7 @@ public class CarpetServerProtocol {
         }
     }
 
-    @ProtocolHandler.PayloadReceiver(payload = CarpetPayload.class, payloadId = "hello")
+    @ProtocolHandler.PayloadReceiver(payload = CarpetPayload.class, key = "hello")
     private static void handleHello(@NotNull ServerPlayer player, @NotNull CarpetServerProtocol.CarpetPayload payload) {
         if (LeavesConfig.protocol.leavesCarpetSupport) {
             if (payload.nbt.contains(HELLO)) {

--- a/leaves-server/src/main/java/org/leavesmc/leaves/protocol/LMSPasterProtocol.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/protocol/LMSPasterProtocol.java
@@ -32,7 +32,7 @@ public class LMSPasterProtocol {
 
     private static final Map<ServerGamePacketListenerImpl, StringBuilder> VERY_LONG_CHATS = new WeakHashMap<>();
 
-    @ProtocolHandler.PayloadReceiver(payload = LmsPasterPayload.class, payloadId = "network_v2")
+    @ProtocolHandler.PayloadReceiver(payload = LmsPasterPayload.class, key = "network_v2")
     public static void handlePackets(ServerPlayer player, LmsPasterPayload payload) {
         if (!LeavesConfig.protocol.lmsPasterProtocol) {
             return;

--- a/leaves-server/src/main/java/org/leavesmc/leaves/protocol/PcaSyncProtocol.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/protocol/PcaSyncProtocol.java
@@ -67,7 +67,7 @@ public class PcaSyncProtocol {
         }
     }
 
-    @ProtocolHandler.PayloadReceiver(payload = EmptyPayload.class, payloadId = "cancel_sync_block_entity")
+    @ProtocolHandler.PayloadReceiver(payload = EmptyPayload.class, key = "cancel_sync_block_entity")
     private static void cancelSyncBlockEntityHandler(ServerPlayer player, EmptyPayload payload) {
         if (!LeavesConfig.protocol.pca.enable) {
             return;
@@ -75,7 +75,7 @@ public class PcaSyncProtocol {
         PcaSyncProtocol.clearPlayerWatchBlock(player);
     }
 
-    @ProtocolHandler.PayloadReceiver(payload = EmptyPayload.class, payloadId = "cancel_sync_entity")
+    @ProtocolHandler.PayloadReceiver(payload = EmptyPayload.class, key = "cancel_sync_entity")
     private static void cancelSyncEntityHandler(ServerPlayer player, EmptyPayload payload) {
         if (!LeavesConfig.protocol.pca.enable) {
             return;
@@ -83,7 +83,7 @@ public class PcaSyncProtocol {
         PcaSyncProtocol.clearPlayerWatchEntity(player);
     }
 
-    @ProtocolHandler.PayloadReceiver(payload = SyncBlockEntityPayload.class, payloadId = "sync_block_entity")
+    @ProtocolHandler.PayloadReceiver(payload = SyncBlockEntityPayload.class, key = "sync_block_entity")
     private static void syncBlockEntityHandler(ServerPlayer player, SyncBlockEntityPayload payload) {
         if (!LeavesConfig.protocol.pca.enable) {
             return;
@@ -127,7 +127,7 @@ public class PcaSyncProtocol {
         });
     }
 
-    @ProtocolHandler.PayloadReceiver(payload = SyncEntityPayload.class, payloadId = "sync_entity")
+    @ProtocolHandler.PayloadReceiver(payload = SyncEntityPayload.class, key = "sync_entity")
     private static void syncEntityHandler(ServerPlayer player, SyncEntityPayload payload) {
         if (!LeavesConfig.protocol.pca.enable) {
             return;

--- a/leaves-server/src/main/java/org/leavesmc/leaves/protocol/bladeren/BladerenProtocol.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/protocol/bladeren/BladerenProtocol.java
@@ -33,7 +33,7 @@ public class BladerenProtocol {
         return ResourceLocation.tryBuild(PROTOCOL_ID, path);
     }
 
-    @ProtocolHandler.PayloadReceiver(payload = BladerenHelloPayload.class, payloadId = "hello")
+    @ProtocolHandler.PayloadReceiver(payload = BladerenHelloPayload.class, key = "hello")
     private static void handleHello(@NotNull ServerPlayer player, @NotNull BladerenHelloPayload payload) {
         if (LeavesConfig.protocol.bladeren.enable) {
             String clientVersion = payload.version;
@@ -52,7 +52,7 @@ public class BladerenProtocol {
         }
     }
 
-    @ProtocolHandler.PayloadReceiver(payload = BladerenFeatureModifyPayload.class, payloadId = "feature_modify")
+    @ProtocolHandler.PayloadReceiver(payload = BladerenFeatureModifyPayload.class, key = "feature_modify")
     private static void handleModify(@NotNull ServerPlayer player, @NotNull BladerenFeatureModifyPayload payload) {
         if (LeavesConfig.protocol.bladeren.enable) {
             String name = payload.name;

--- a/leaves-server/src/main/java/org/leavesmc/leaves/protocol/chatimage/ChatImageProtocol.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/protocol/chatimage/ChatImageProtocol.java
@@ -27,7 +27,7 @@ public class ChatImageProtocol {
         return ResourceLocation.tryBuild(PROTOCOL_ID, path);
     }
 
-    @ProtocolHandler.PayloadReceiver(payload = FileChannelPayload.class, payloadId = "get_file_channel")
+    @ProtocolHandler.PayloadReceiver(payload = FileChannelPayload.class, key = "get_file_channel")
     public static void serverFileChannelReceived(ServerPlayer player, FileChannelPayload payload) {
         if (!LeavesConfig.protocol.chatImageProtocol) {
             return;
@@ -52,7 +52,7 @@ public class ChatImageProtocol {
         }
     }
 
-    @ProtocolHandler.PayloadReceiver(payload = FileInfoChannelPayload.class, payloadId = "file_info")
+    @ProtocolHandler.PayloadReceiver(payload = FileInfoChannelPayload.class, key = "file_info")
     public static void serverGetFileChannelReceived(ServerPlayer player, FileInfoChannelPayload packet) {
         if (!LeavesConfig.protocol.chatImageProtocol) {
             return;

--- a/leaves-server/src/main/java/org/leavesmc/leaves/protocol/core/InvokerHolder.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/protocol/core/InvokerHolder.java
@@ -1,0 +1,45 @@
+package org.leavesmc.leaves.protocol.core;
+
+import io.netty.buffer.ByteBuf;
+import net.minecraft.server.level.ServerPlayer;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+public record InvokerHolder<T>(LeavesProtocol owner, Method invoker, T handler) {
+
+    private void invoke0(Object... args) {
+        if (!owner.isActive()) {
+            return;
+        }
+        try {
+            if (Modifier.isStatic(invoker.getModifiers())) {
+                invoker.invoke(null, args);
+            } else {
+                invoker.invoke(owner, args);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void invokeEmpty() {
+        invoke0();
+    }
+
+    public void invokePlayer(ServerPlayer player) {
+        invoke0(player);
+    }
+
+    public void invokeBuf(ServerPlayer player, ByteBuf buf) {
+        invoke0(player, ProtocolUtils.decorate(buf));
+    }
+
+    public void invokePayload(ServerPlayer player, LeavesCustomPayload<?> payload) {
+        invoke0(player, payload);
+    }
+
+    public void invokeString(ServerPlayer player, String channelId) {
+        invoke0(player, channelId);
+    }
+}

--- a/leaves-server/src/main/java/org/leavesmc/leaves/protocol/core/LeavesCustomPayload.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/protocol/core/LeavesCustomPayload.java
@@ -1,25 +1,14 @@
 package org.leavesmc.leaves.protocol.core;
 
-import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.NotNull;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-
 public interface LeavesCustomPayload<T extends LeavesCustomPayload<T>> extends CustomPacketPayload {
 
-    @Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
-    @Retention(RetentionPolicy.RUNTIME)
-    @interface New {
+    default ResourceLocation id() {
+        return null;
     }
-
-    void write(FriendlyByteBuf buf);
-
-    ResourceLocation id();
 
     @Override
     @NotNull

--- a/leaves-server/src/main/java/org/leavesmc/leaves/protocol/core/LeavesProtocol.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/protocol/core/LeavesProtocol.java
@@ -5,8 +5,13 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Target(ElementType.TYPE)
-@Retention(RetentionPolicy.RUNTIME)
-public @interface LeavesProtocol {
-    String[] namespace();
+public interface LeavesProtocol {
+
+    boolean isActive();
+
+    @Target(ElementType.TYPE)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface Register {
+        String namespace();
+    }
 }

--- a/leaves-server/src/main/java/org/leavesmc/leaves/protocol/core/ProtocolHandler.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/protocol/core/ProtocolHandler.java
@@ -7,6 +7,12 @@ import java.lang.annotation.Target;
 
 public class ProtocolHandler {
 
+    @Target(ElementType.FIELD)
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface Codec {
+        String key() default "";
+    }
+
     @Target(ElementType.METHOD)
     @Retention(RetentionPolicy.RUNTIME)
     public @interface Init {
@@ -17,9 +23,16 @@ public class ProtocolHandler {
     public @interface PayloadReceiver {
         Class<? extends LeavesCustomPayload<?>> payload();
 
-        String[] payloadId() default "";
+        String key() default "";
 
-        boolean ignoreId() default false;
+        boolean sendFabricRegister() default true;
+    }
+
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface BytebufReceiver {
+
+        String key() default "";
 
         boolean sendFabricRegister() default true;
     }
@@ -27,7 +40,7 @@ public class ProtocolHandler {
     @Target(ElementType.METHOD)
     @Retention(RetentionPolicy.RUNTIME)
     public @interface Ticker {
-        int delay() default 0;
+        int interval() default 1;
     }
 
     @Target(ElementType.METHOD)
@@ -48,7 +61,7 @@ public class ProtocolHandler {
     @Target(ElementType.METHOD)
     @Retention(RetentionPolicy.RUNTIME)
     public @interface MinecraftRegister {
-        String[] channelId() default "";
+        String key() default "";
 
         boolean ignoreId() default false;
     }

--- a/leaves-server/src/main/java/org/leavesmc/leaves/protocol/jade/JadeProtocol.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/protocol/jade/JadeProtocol.java
@@ -165,7 +165,7 @@ public class JadeProtocol {
         rebuildShearableBlocks();
     }
 
-    @ProtocolHandler.PayloadReceiver(payload = ClientHandshakePayload.class, payloadId = "client_handshake")
+    @ProtocolHandler.PayloadReceiver(payload = ClientHandshakePayload.class, key = "client_handshake")
     public static void clientHandshake(ServerPlayer player, ClientHandshakePayload payload) {
         if (!LeavesConfig.protocol.jadeProtocol) {
             return;
@@ -184,7 +184,7 @@ public class JadeProtocol {
         enabledPlayers.remove(player);
     }
 
-    @ProtocolHandler.PayloadReceiver(payload = RequestEntityPayload.class, payloadId = "request_entity")
+    @ProtocolHandler.PayloadReceiver(payload = RequestEntityPayload.class, key = "request_entity")
     public static void requestEntityData(ServerPlayer player, RequestEntityPayload payload) {
         if (!LeavesConfig.protocol.jadeProtocol) {
             return;
@@ -224,7 +224,7 @@ public class JadeProtocol {
         });
     }
 
-    @ProtocolHandler.PayloadReceiver(payload = RequestBlockPayload.class, payloadId = "request_block")
+    @ProtocolHandler.PayloadReceiver(payload = RequestBlockPayload.class, key = "request_block")
     public static void requestBlockData(ServerPlayer player, RequestBlockPayload payload) {
         if (!LeavesConfig.protocol.jadeProtocol) {
             return;

--- a/leaves-server/src/main/java/org/leavesmc/leaves/protocol/rei/REIServerProtocol.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/protocol/rei/REIServerProtocol.java
@@ -200,7 +200,7 @@ public class REIServerProtocol {
         }
     }
 
-    @ProtocolHandler.PayloadReceiver(payload = BufCustomPacketPayload.class, payloadId = "delete_item")
+    @ProtocolHandler.PayloadReceiver(payload = BufCustomPacketPayload.class, key = "delete_item")
     public static void handleDeleteItem(ServerPlayer player, BufCustomPacketPayload payload) {
         if (!LeavesConfig.protocol.reiServerProtocol || !hasCheatPermission(player)) {
             return;
@@ -217,7 +217,7 @@ public class REIServerProtocol {
         });
     }
 
-    @ProtocolHandler.PayloadReceiver(payload = BufCustomPacketPayload.class, payloadId = "create_item")
+    @ProtocolHandler.PayloadReceiver(payload = BufCustomPacketPayload.class, key = "create_item")
     public static void handleCreateItem(ServerPlayer player, BufCustomPacketPayload payload) {
         if (!LeavesConfig.protocol.reiServerProtocol || !hasCheatPermission(player)) {
             return;
@@ -244,7 +244,7 @@ public class REIServerProtocol {
         inboundTransform(player, payload.id(), c2sBuf, consumer);
     }
 
-    @ProtocolHandler.PayloadReceiver(payload = BufCustomPacketPayload.class, payloadId = "create_item_grab")
+    @ProtocolHandler.PayloadReceiver(payload = BufCustomPacketPayload.class, key = "create_item_grab")
     public static void handleCreateItemGrab(ServerPlayer player, BufCustomPacketPayload payload) {
         if (!LeavesConfig.protocol.reiServerProtocol || !hasCheatPermission(player)) {
             return;
@@ -277,7 +277,7 @@ public class REIServerProtocol {
         inboundTransform(player, payload.id(), c2sBuf, consumer);
     }
 
-    @ProtocolHandler.PayloadReceiver(payload = BufCustomPacketPayload.class, payloadId = "create_item_hotbar")
+    @ProtocolHandler.PayloadReceiver(payload = BufCustomPacketPayload.class, key = "create_item_hotbar")
     public static void handleCreateItemHotbar(ServerPlayer player, BufCustomPacketPayload payload) {
         if (!LeavesConfig.protocol.reiServerProtocol || !hasCheatPermission(player)) {
             return;

--- a/leaves-server/src/main/java/org/leavesmc/leaves/protocol/servux/ServuxEntityDataProtocol.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/protocol/servux/ServuxEntityDataProtocol.java
@@ -41,7 +41,7 @@ public class ServuxEntityDataProtocol {
         sendMetadata(player);
     }
 
-    @ProtocolHandler.PayloadReceiver(payload = EntityDataPayload.class, payloadId = "entity_data")
+    @ProtocolHandler.PayloadReceiver(payload = EntityDataPayload.class, key = "entity_data")
     public static void onPacketReceive(ServerPlayer player, EntityDataPayload payload) {
         if (!LeavesConfig.protocol.servux.entityProtocol) {
             return;

--- a/leaves-server/src/main/java/org/leavesmc/leaves/protocol/servux/ServuxHudDataProtocol.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/protocol/servux/ServuxHudDataProtocol.java
@@ -8,6 +8,7 @@ import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.NbtOps;
 import net.minecraft.nbt.Tag;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
@@ -39,7 +40,7 @@ public class ServuxHudDataProtocol {
 
     public static boolean refreshSpawnMetadata = false;
 
-    @ProtocolHandler.PayloadReceiver(payload = HudDataPayload.class, payloadId = "hud_metadata")
+    @ProtocolHandler.PayloadReceiver(payload = HudDataPayload.class, key = "hud_metadata")
     public static void onPacketReceive(ServerPlayer player, HudDataPayload payload) {
         if (!LeavesConfig.protocol.servux.hudMetadataProtocol) {
             return;
@@ -224,7 +225,6 @@ public class ServuxHudDataProtocol {
             this(type, new CompoundTag(), buffer);
         }
 
-        @New
         @NotNull
         public static HudDataPayload decode(ResourceLocation location, @NotNull FriendlyByteBuf buf) {
             HudDataPayloadType type = HudDataPayloadType.fromId(buf.readVarInt());

--- a/leaves-server/src/main/java/org/leavesmc/leaves/protocol/servux/ServuxStructuresProtocol.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/protocol/servux/ServuxStructuresProtocol.java
@@ -51,7 +51,7 @@ public class ServuxStructuresProtocol {
     private static final Map<Integer, ServerPlayer> players = new ConcurrentHashMap<>();
     private static final Map<UUID, Map<ChunkPos, Timeout>> timeouts = new HashMap<>();
 
-    @ProtocolHandler.PayloadReceiver(payload = StructuresPayload.class, payloadId = "structures")
+    @ProtocolHandler.PayloadReceiver(payload = StructuresPayload.class, key = "structures")
     public static void onPacketReceive(ServerPlayer player, StructuresPayload payload) {
         if (!LeavesConfig.protocol.servux.structureProtocol) {
             return;

--- a/leaves-server/src/main/java/org/leavesmc/leaves/protocol/servux/litematics/ServuxLitematicsProtocol.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/protocol/servux/litematics/ServuxLitematicsProtocol.java
@@ -83,7 +83,7 @@ public class ServuxLitematicsProtocol {
         encodeServerData(player, payload);
     }
 
-    @ProtocolHandler.PayloadReceiver(payload = ServuxLitematicaPayload.class, payloadId = "litematics")
+    @ProtocolHandler.PayloadReceiver(payload = ServuxLitematicaPayload.class, key = "litematics")
     public static void onPacketReceive(ServerPlayer player, ServuxLitematicaPayload payload) {
         if (!isEnabled() || !hasPermission(player)) {
             return;

--- a/leaves-server/src/main/java/org/leavesmc/leaves/protocol/syncmatica/CommunicationManager.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/protocol/syncmatica/CommunicationManager.java
@@ -94,7 +94,7 @@ public class CommunicationManager {
         playerMap.remove(oldPlayer);
     }
 
-    @ProtocolHandler.PayloadReceiver(payload = SyncmaticaPayload.class, payloadId = "main")
+    @ProtocolHandler.PayloadReceiver(payload = SyncmaticaPayload.class, key = "main")
     public static void onPacketGet(ServerPlayer player, SyncmaticaPayload payload) {
         if (!LeavesConfig.protocol.syncmatica.enable) {
             return;


### PR DESCRIPTION
所有的更改:
1. 现在每个LeavesProtocol都需要标注 isActive，但原有的扫描+注解的创建方式不变
2. LeavesCustomPayload 与 @Codec 和 StreamCodec 绑定，并通过 LeavesProtocolManager 集中处理 en/decode
3. 原有的@New write 方法全部丢弃
4. 添加了@BytebufReceiver用于处理简单的payload
5. 原有的Ticker改为 Interval 即每k个tick执行一次
6. 待完成