### PR TITLE
Recheck for null before handling player join

### DIFF
--- a/leaves-server/minecraft-patches/features/0004-Leaves-Protocol-Core.patch
+++ b/leaves-server/minecraft-patches/features/0004-Leaves-Protocol-Core.patch
@@ -109,19 +109,22 @@ index 186393485396cfe9b1baef29586198356e2d2600..ac5ef04fae4bc19bae9007c0ffd8f688
              this.getCraftPlayer().removeChannel(channel);
          }
 diff --git a/net/minecraft/server/players/PlayerList.java b/net/minecraft/server/players/PlayerList.java
-index 9ca3c55a3b5b1a532b86b08eb92460df4cb54f2a..2648a3ad296f59ee554783cdd4c7e889d0447f5b 100644
+index 9ca3c55a3b5b1a532b86b08eb92460df4cb54f2a..722b4eb1eabe167233f75bd50bbf47e369670eaa 100644
 --- a/net/minecraft/server/players/PlayerList.java
 +++ b/net/minecraft/server/players/PlayerList.java
-@@ -334,6 +334,8 @@ public abstract class PlayerList {
+@@ -334,6 +334,11 @@ public abstract class PlayerList {
              return;
          }
  
-+        org.leavesmc.leaves.protocol.core.LeavesProtocolManager.handlePlayerJoin(player); // Leaves - protocol
++        // Leaves start - protocol core
++        if (player.internalConnection == null) player.internalConnection = connection;
++        org.leavesmc.leaves.protocol.core.LeavesProtocolManager.handlePlayerJoin(player);
++        // Leaves end - protocol core
 +
          final net.kyori.adventure.text.Component jm = playerJoinEvent.joinMessage();
  
          if (jm != null && !jm.equals(net.kyori.adventure.text.Component.empty())) { // Paper - Adventure
-@@ -504,6 +506,7 @@ public abstract class PlayerList {
+@@ -504,6 +509,7 @@ public abstract class PlayerList {
          return this.remove(player, net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, io.papermc.paper.configuration.GlobalConfiguration.get().messages.useDisplayNameInQuitMessage ? player.getBukkitEntity().displayName() : io.papermc.paper.adventure.PaperAdventure.asAdventure(player.getDisplayName())));
      }
      public @Nullable net.kyori.adventure.text.Component remove(ServerPlayer player, net.kyori.adventure.text.Component leaveMessage) {
@@ -129,7 +132,7 @@ index 9ca3c55a3b5b1a532b86b08eb92460df4cb54f2a..2648a3ad296f59ee554783cdd4c7e889
          // Paper end - Fix kick event leave message not being sent
          ServerLevel serverLevel = player.serverLevel();
          player.awardStat(Stats.LEAVE_GAME);
-@@ -628,6 +631,7 @@ public abstract class PlayerList {
+@@ -628,6 +634,7 @@ public abstract class PlayerList {
          SocketAddress socketAddress = loginlistener.connection.getRemoteAddress();
  
          ServerPlayer entity = new ServerPlayer(this.server, this.server.getLevel(Level.OVERWORLD), gameProfile, ClientInformation.createDefault());
@@ -137,7 +140,7 @@ index 9ca3c55a3b5b1a532b86b08eb92460df4cb54f2a..2648a3ad296f59ee554783cdd4c7e889
          entity.transferCookieConnection = loginlistener;
          org.bukkit.entity.Player player = entity.getBukkitEntity();
          org.bukkit.event.player.PlayerLoginEvent event = new org.bukkit.event.player.PlayerLoginEvent(player, loginlistener.connection.hostname, ((java.net.InetSocketAddress) socketAddress).getAddress(), ((java.net.InetSocketAddress) loginlistener.connection.channel.remoteAddress()).getAddress());
-@@ -1418,6 +1422,7 @@ public abstract class PlayerList {
+@@ -1418,6 +1425,7 @@ public abstract class PlayerList {
              serverPlayer.connection.send(clientboundUpdateRecipesPacket);
              serverPlayer.getRecipeBook().sendInitialRecipeBook(serverPlayer);
          }

--- a/leaves-server/minecraft-patches/features/0007-Leaves-Fakeplayer.patch
+++ b/leaves-server/minecraft-patches/features/0007-Leaves-Fakeplayer.patch
@@ -213,12 +213,12 @@ index 443bfb06951f0ffe6af8724b53e150cd0907e68d..01687ea3acf449c49cbc615887a7dbdd
                  // CraftBukkit start
                  org.bukkit.event.player.PlayerChangedWorldEvent changeEvent = new org.bukkit.event.player.PlayerChangedWorldEvent(this.getBukkitEntity(), serverLevel.getWorld());
 diff --git a/net/minecraft/server/players/PlayerList.java b/net/minecraft/server/players/PlayerList.java
-index 2648a3ad296f59ee554783cdd4c7e889d0447f5b..3d2b565ddb488aff3e80430e4eff5c233549edb0 100644
+index 722b4eb1eabe167233f75bd50bbf47e369670eaa..0cf30681a9e3d68f3abe1d87b9fd4220083685a9 100644
 --- a/net/minecraft/server/players/PlayerList.java
 +++ b/net/minecraft/server/players/PlayerList.java
-@@ -336,6 +336,19 @@ public abstract class PlayerList {
- 
-         org.leavesmc.leaves.protocol.core.LeavesProtocolManager.handlePlayerJoin(player); // Leaves - protocol
+@@ -339,6 +339,19 @@ public abstract class PlayerList {
+         org.leavesmc.leaves.protocol.core.LeavesProtocolManager.handlePlayerJoin(player);
+         // Leaves end - protocol core
  
 +        // Leaves start - bot support
 +        if (org.leavesmc.leaves.LeavesConfig.modify.fakeplayer.enable) {
@@ -236,7 +236,7 @@ index 2648a3ad296f59ee554783cdd4c7e889d0447f5b..3d2b565ddb488aff3e80430e4eff5c23
          final net.kyori.adventure.text.Component jm = playerJoinEvent.joinMessage();
  
          if (jm != null && !jm.equals(net.kyori.adventure.text.Component.empty())) { // Paper - Adventure
-@@ -867,6 +880,12 @@ public abstract class PlayerList {
+@@ -870,6 +883,12 @@ public abstract class PlayerList {
          }
          // Paper end - Add PlayerPostRespawnEvent
  
@@ -249,7 +249,7 @@ index 2648a3ad296f59ee554783cdd4c7e889d0447f5b..3d2b565ddb488aff3e80430e4eff5c23
          // CraftBukkit end
  
          return serverPlayer;
-@@ -971,11 +990,16 @@ public abstract class PlayerList {
+@@ -974,11 +993,16 @@ public abstract class PlayerList {
      }
  
      public String[] getPlayerNamesArray() {
@@ -267,7 +267,7 @@ index 2648a3ad296f59ee554783cdd4c7e889d0447f5b..3d2b565ddb488aff3e80430e4eff5c23
  
          return strings;
      }
-@@ -1061,7 +1085,14 @@ public abstract class PlayerList {
+@@ -1064,7 +1088,14 @@ public abstract class PlayerList {
  
      @Nullable
      public ServerPlayer getPlayerByName(String username) {
@@ -283,7 +283,7 @@ index 2648a3ad296f59ee554783cdd4c7e889d0447f5b..3d2b565ddb488aff3e80430e4eff5c23
      }
  
      public void broadcast(@Nullable Player except, double x, double y, double z, double radius, ResourceKey<Level> dimension, Packet<?> packet) {
-@@ -1377,7 +1408,13 @@ public abstract class PlayerList {
+@@ -1380,7 +1411,13 @@ public abstract class PlayerList {
  
      @Nullable
      public ServerPlayer getPlayer(UUID playerUUID) {

--- a/leaves-server/minecraft-patches/features/0015-No-chat-sign.patch
+++ b/leaves-server/minecraft-patches/features/0015-No-chat-sign.patch
@@ -133,10 +133,10 @@ index ac5ef04fae4bc19bae9007c0ffd8f688434d22d7..649aeec6954d26cb67827e99c4b5b736
          if (packet == null || this.processedDisconnect) { // Spigot
              return;
 diff --git a/net/minecraft/server/players/PlayerList.java b/net/minecraft/server/players/PlayerList.java
-index 012574f56d9d7e6340c8b7bf7bee43e36d99df65..ffa92892ab4e1e079fa058a270877a9654624875 100644
+index 0cf30681a9e3d68f3abe1d87b9fd4220083685a9..491d7b5a0cc099a3eb658e19cbe9d97b4419382c 100644
 --- a/net/minecraft/server/players/PlayerList.java
 +++ b/net/minecraft/server/players/PlayerList.java
-@@ -1336,7 +1336,7 @@ public abstract class PlayerList {
+@@ -1339,7 +1339,7 @@ public abstract class PlayerList {
      }
  
      public boolean verifyChatTrusted(PlayerChatMessage message) {

--- a/leaves-server/minecraft-patches/features/0035-Return-nether-portal-fix.patch
+++ b/leaves-server/minecraft-patches/features/0035-Return-nether-portal-fix.patch
@@ -32,10 +32,10 @@ index 66110486725de7967e55839043b9fc9690e4c0f5..f144a8bd5eb55ce093ad92ffd1304860
                  if (this.isBlocking()) {
                      this.stopUsingItem();
 diff --git a/net/minecraft/server/players/PlayerList.java b/net/minecraft/server/players/PlayerList.java
-index b4a4ba86fd6023db33b2ee9cb02ec41f9733a813..3b612c02ddbf25c6dcfe5df14fca027986e6f252 100644
+index 491d7b5a0cc099a3eb658e19cbe9d97b4419382c..72c2762485da81d3a252290455f57a8cf81dfe66 100644
 --- a/net/minecraft/server/players/PlayerList.java
 +++ b/net/minecraft/server/players/PlayerList.java
-@@ -860,6 +860,20 @@ public abstract class PlayerList {
+@@ -863,6 +863,20 @@ public abstract class PlayerList {
          if (fromWorld != level) {
              org.bukkit.event.player.PlayerChangedWorldEvent event = new org.bukkit.event.player.PlayerChangedWorldEvent(player.getBukkitEntity(), fromWorld.getWorld());
              this.server.server.getPluginManager().callEvent(event);

--- a/leaves-server/minecraft-patches/features/0075-Replay-Mod-API.patch
+++ b/leaves-server/minecraft-patches/features/0075-Replay-Mod-API.patch
@@ -142,7 +142,7 @@ index 5fd09fe2c544d197035f4500a0672f73b1da2501..27729923db521bc5b875badb1ee3fe75
                  }
                  // Leaves end - skip
 diff --git a/net/minecraft/server/players/PlayerList.java b/net/minecraft/server/players/PlayerList.java
-index f2442fbf0cee7a2d1c3a155ec38d6a7eca36d6e8..e33776c039e36f55f0579b51b147d7be087839cf 100644
+index 72c2762485da81d3a252290455f57a8cf81dfe66..0dee4945feb6d4cb2f520d346bf8be4fa36fb868 100644
 --- a/net/minecraft/server/players/PlayerList.java
 +++ b/net/minecraft/server/players/PlayerList.java
 @@ -131,6 +131,7 @@ public abstract class PlayerList {
@@ -281,7 +281,7 @@ index f2442fbf0cee7a2d1c3a155ec38d6a7eca36d6e8..e33776c039e36f55f0579b51b147d7be
          this.playersByName.put(player.getScoreboardName().toLowerCase(java.util.Locale.ROOT), player); // Spigot
          this.playersByUUID.put(player.getUUID(), player);
          // this.broadcastAll(ClientboundPlayerInfoUpdatePacket.createPlayerInitializing(List.of(player))); // CraftBukkit - replaced with loop below
-@@ -380,6 +495,12 @@ public abstract class PlayerList {
+@@ -383,6 +498,12 @@ public abstract class PlayerList {
                  continue;
              }
  
@@ -294,7 +294,7 @@ index f2442fbf0cee7a2d1c3a155ec38d6a7eca36d6e8..e33776c039e36f55f0579b51b147d7be
              onlinePlayers.add(entityplayer1); // Paper - Use single player info update packet on join
          }
          // Paper start - Use single player info update packet on join
-@@ -514,6 +635,43 @@ public abstract class PlayerList {
+@@ -517,6 +638,43 @@ public abstract class PlayerList {
          }
      }
  
@@ -338,7 +338,7 @@ index f2442fbf0cee7a2d1c3a155ec38d6a7eca36d6e8..e33776c039e36f55f0579b51b147d7be
      public @Nullable net.kyori.adventure.text.Component remove(ServerPlayer player) { // CraftBukkit - return string // Paper - return Component
          // Paper start - Fix kick event leave message not being sent
          return this.remove(player, net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, io.papermc.paper.configuration.GlobalConfiguration.get().messages.useDisplayNameInQuitMessage ? player.getBukkitEntity().displayName() : io.papermc.paper.adventure.PaperAdventure.asAdventure(player.getDisplayName())));
-@@ -589,6 +747,7 @@ public abstract class PlayerList {
+@@ -592,6 +750,7 @@ public abstract class PlayerList {
          player.retireScheduler(); // Paper - Folia schedulers
          player.getAdvancements().stopListening();
          this.players.remove(player);
@@ -346,7 +346,7 @@ index f2442fbf0cee7a2d1c3a155ec38d6a7eca36d6e8..e33776c039e36f55f0579b51b147d7be
          this.playersByName.remove(player.getScoreboardName().toLowerCase(java.util.Locale.ROOT)); // Spigot
          this.server.getCustomBossEvents().onPlayerDisconnect(player);
          UUID uuid = player.getUUID();
-@@ -680,7 +839,7 @@ public abstract class PlayerList {
+@@ -683,7 +842,7 @@ public abstract class PlayerList {
              // return this.players.size() >= this.maxPlayers && !this.canBypassPlayerLimit(gameProfile)
              //     ? Component.translatable("multiplayer.disconnect.server_full")
              //     : null;

--- a/leaves-server/minecraft-patches/features/0113-Xaero-Map-Protocol.patch
+++ b/leaves-server/minecraft-patches/features/0113-Xaero-Map-Protocol.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Xaero Map Protocol
 
 
 diff --git a/net/minecraft/server/players/PlayerList.java b/net/minecraft/server/players/PlayerList.java
-index 28456eab6d5c31cf33fd9918d7306b078a97bd41..4b28145e73664ad3149d978b7ec1e1d3915f3cdc 100644
+index df58e2cd1a8be7c4b24a747ca40d0e79bf40f976..f6c2f02e1a7f5ac2d7bb584893457761fe30b509 100644
 --- a/net/minecraft/server/players/PlayerList.java
 +++ b/net/minecraft/server/players/PlayerList.java
-@@ -1340,6 +1340,7 @@ public abstract class PlayerList {
+@@ -1343,6 +1343,7 @@ public abstract class PlayerList {
          player.connection.send(new ClientboundInitializeBorderPacket(worldBorder));
          player.connection.send(new ClientboundSetTimePacket(level.getGameTime(), level.getDayTime(), level.getGameRules().getBoolean(GameRules.RULE_DAYLIGHT)));
          player.connection.send(new ClientboundSetDefaultSpawnPositionPacket(level.getSharedSpawnPos(), level.getSharedSpawnAngle()));


### PR DESCRIPTION
Recheck nullability of internalConnection in placeNewPlayer.

Most fake player plugins don't call `canPlayerLogin`, which Leaves assigns value to internalConnection.

After directly calling `placeNewPlayer`, everything breaks.

Orginally discovered in [Leaf](https://github.com/Winds-Studio/Leaf/issues/370), now pr to upstream

Leaves have built-in fake player tho, but some users may install other plugins to fulfil their needs