### PR TITLE
Fix bot infinity desync

### DIFF
--- a/leaves-server/minecraft-patches/features/0072-Bow-infinity-fix.patch
+++ b/leaves-server/minecraft-patches/features/0072-Bow-infinity-fix.patch
@@ -5,15 +5,19 @@ Subject: [PATCH] Bow infinity fix
 
 
 diff --git a/net/minecraft/world/entity/player/Player.java b/net/minecraft/world/entity/player/Player.java
-index ee8c0d0edbb296106a128c48f4186ba3a5bf9df8..0f1a398c588b7e0832612a50734b7db8b3a48ccc 100644
+index ee8c0d0edbb296106a128c48f4186ba3a5bf9df8..6c32b0e26a77c808fb16fc420e89fcebbea56ab1 100644
 --- a/net/minecraft/world/entity/player/Player.java
 +++ b/net/minecraft/world/entity/player/Player.java
-@@ -2170,7 +2170,7 @@ public abstract class Player extends LivingEntity {
+@@ -2169,8 +2169,10 @@ public abstract class Player extends LivingEntity {
+                     }
                  }
  
-                 if (anyEventCancelled.booleanValue() && !this.abilities.instabuild && this instanceof final ServerPlayer player) this.resyncUsingItem(player); // Paper - resync if no item matched the Predicate
+-                if (anyEventCancelled.booleanValue() && !this.abilities.instabuild && this instanceof final ServerPlayer player) this.resyncUsingItem(player); // Paper - resync if no item matched the Predicate
 -                return this.hasInfiniteMaterials() ? new ItemStack(Items.ARROW) : ItemStack.EMPTY;
-+                return this.hasInfiniteMaterials() || (org.leavesmc.leaves.LeavesConfig.modify.bowInfinityFix && net.minecraft.world.item.enchantment.EnchantmentHelper.processAmmoUse((ServerLevel) this.level(), shootable, new ItemStack(Items.ARROW), 1) <= 0) ? new ItemStack(Items.ARROW) : ItemStack.EMPTY;
++                // Leaves start - bow infinity fix
++                if ((org.leavesmc.leaves.LeavesConfig.modify.bowInfinityFix || anyEventCancelled.booleanValue()) && !this.abilities.instabuild && this instanceof final ServerPlayer player) this.resyncUsingItem(player); // Paper - resync if no item matched the Predicate
++                return org.leavesmc.leaves.LeavesConfig.modify.bowInfinityFix ? net.minecraft.world.item.enchantment.EnchantmentHelper.processAmmoUse((ServerLevel) this.level(), shootable, new ItemStack(Items.ARROW), 1) <= 0 ? new ItemStack(Items.ARROW) : ItemStack.EMPTY : this.hasInfiniteMaterials() ? new ItemStack(Items.ARROW) : ItemStack.EMPTY;
++                // Leaves end - bow infinity fix
              }
          }
      }


### PR DESCRIPTION
问题来自副手盾牌/食物时 背包无箭时拉弓 会导致客户端使用副手物品而服务端使用弓