### PR TITLE
Fix bot use actions

### DIFF
--- a/leaves-server/src/main/java/org/leavesmc/leaves/bot/ServerBot.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/bot/ServerBot.java
@@ -500,13 +500,9 @@ public class ServerBot extends ServerPlayer {
         List<Entity> entities = this.level().getEntities((Entity) null, this.getBoundingBox(), (e -> e != this && (predicate == null || predicate.test(e))));
         if (!entities.isEmpty()) {
             return entities.getFirst();
-        } else {
-            EntityHitResult result = this.getBukkitEntity().rayTraceEntity(maxDistance, false);
-            if (result != null && (predicate == null || predicate.test(result.getEntity()))) {
-                return result.getEntity();
-            }
         }
-        return null;
+        EntityHitResult hitResult = getEntityHitResult(maxDistance, predicate);
+        return hitResult == null ? null : hitResult.getEntity();
     }
 
     public EntityHitResult getEntityHitResult(int maxDistance, Predicate<? super Entity> predicate) {

--- a/leaves-server/src/main/java/org/leavesmc/leaves/bot/ServerBot.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/bot/ServerBot.java
@@ -509,6 +509,14 @@ public class ServerBot extends ServerPlayer {
         return null;
     }
 
+    public EntityHitResult getEntityHitResult(int maxDistance, Predicate<? super Entity> predicate) {
+        EntityHitResult result = this.getBukkitEntity().rayTraceEntity(maxDistance, false);
+        if (result != null && (predicate == null || predicate.test(result.getEntity()))) {
+            return result;
+        }
+        return null;
+    }
+
     public void dropAll(boolean death) {
         NonNullList<ItemStack> items = this.getInventory().getNonEquipmentItems();
         for (int i = 0; i < items.size(); i++) {

--- a/leaves-server/src/main/java/org/leavesmc/leaves/bot/ServerBot.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/bot/ServerBot.java
@@ -506,7 +506,7 @@ public class ServerBot extends ServerPlayer {
     }
 
     public EntityHitResult getEntityHitResult(int maxDistance, Predicate<? super Entity> predicate) {
-        EntityHitResult result = this.getBukkitEntity().rayTraceEntity(maxDistance, false);
+        EntityHitResult result = this.getTargetEntity(maxDistance);
         if (result != null && (predicate == null || predicate.test(result.getEntity()))) {
             return result;
         }

--- a/leaves-server/src/main/java/org/leavesmc/leaves/bot/agent/actions/ServerAttackAction.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/bot/agent/actions/ServerAttackAction.java
@@ -1,6 +1,6 @@
 package org.leavesmc.leaves.bot.agent.actions;
 
-import net.minecraft.world.entity.Entity;
+import net.minecraft.world.phys.EntityHitResult;
 import org.jetbrains.annotations.NotNull;
 import org.leavesmc.leaves.bot.ServerBot;
 import org.leavesmc.leaves.entity.bot.actions.CraftAttackAction;
@@ -13,11 +13,11 @@ public class ServerAttackAction extends ServerTimerBotAction<ServerAttackAction>
 
     @Override
     public boolean doTick(@NotNull ServerBot bot) {
-        Entity entity = bot.getTargetEntity(3, target -> target.isAttackable() && !target.skipAttackInteraction(bot));
-        if (entity == null) {
+        EntityHitResult hitResult = bot.getEntityHitResult(3, target -> target.isAttackable() && !target.skipAttackInteraction(bot));
+        if (hitResult == null) {
             return false;
         } else {
-            bot.attack(entity);
+            bot.attack(hitResult.getEntity());
             return true;
         }
     }

--- a/leaves-server/src/main/java/org/leavesmc/leaves/bot/agent/actions/ServerUseItemAutoAction.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/bot/agent/actions/ServerUseItemAutoAction.java
@@ -80,7 +80,7 @@ public class ServerUseItemAutoAction extends ServerTimerBotAction<ServerUseItemA
         boolean mainSuccess, useTo = entityHitResult != null, useOn = !bot.level().getBlockState(blockHitResult.getBlockPos()).isAir();
         if (useTo) {
             InteractionResult result = ServerUseItemToAction.execute(bot, entityHitResult);
-            mainSuccess = result.consumesAction() || result == InteractionResult.PASS && ServerUseItemAction.execute(bot);
+            mainSuccess = result.consumesAction() || (result == InteractionResult.PASS && ServerUseItemAction.execute(bot));
         } else if (useOn) {
             mainSuccess = ServerUseItemOnAction.execute(bot, blockHitResult) || ServerUseItemAction.execute(bot);
         } else {

--- a/leaves-server/src/main/java/org/leavesmc/leaves/bot/agent/actions/ServerUseItemAutoAction.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/bot/agent/actions/ServerUseItemAutoAction.java
@@ -2,7 +2,6 @@ package org.leavesmc.leaves.bot.agent.actions;
 
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionResult;
-import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.ClipContext;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.EntityHitResult;

--- a/leaves-server/src/main/java/org/leavesmc/leaves/bot/agent/actions/ServerUseItemAutoAction.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/bot/agent/actions/ServerUseItemAutoAction.java
@@ -78,7 +78,7 @@ public class ServerUseItemAutoAction extends ServerTimerBotAction<ServerUseItemA
         BlockHitResult blockHitResult = (BlockHitResult) bot.getRayTrace(5, ClipContext.Fluid.NONE);
         boolean mainSuccess, useTo = entity != null, useOn = !bot.level().getBlockState(blockHitResult.getBlockPos()).isAir();
         if (useTo) {
-            mainSuccess = ServerUseItemToAction.execute(bot, entity) || ServerUseItemAction.execute(bot);
+            mainSuccess = ServerUseItemToAction.execute(bot, entity);
         } else if (useOn) {
             mainSuccess = ServerUseItemOnAction.execute(bot, blockHitResult) || ServerUseItemAction.execute(bot);
         } else {
@@ -88,7 +88,7 @@ public class ServerUseItemAutoAction extends ServerTimerBotAction<ServerUseItemA
             return true;
         }
         if (useTo) {
-            return ServerUseItemToOffhandAction.execute(bot, entity) || ServerUseItemOffhandAction.execute(bot);
+            return ServerUseItemToOffhandAction.execute(bot, entity);
         } else if (useOn) {
             return ServerUseItemOnOffhandAction.execute(bot, blockHitResult) || ServerUseItemOffhandAction.execute(bot);
         } else {

--- a/leaves-server/src/main/java/org/leavesmc/leaves/bot/agent/actions/ServerUseItemAutoAction.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/bot/agent/actions/ServerUseItemAutoAction.java
@@ -1,9 +1,11 @@
 package org.leavesmc.leaves.bot.agent.actions;
 
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.ClipContext;
 import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.EntityHitResult;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.NotNull;
 import org.leavesmc.leaves.bot.ServerBot;
@@ -74,11 +76,12 @@ public class ServerUseItemAutoAction extends ServerTimerBotAction<ServerUseItemA
             return false;
         }
 
-        Entity entity = bot.getTargetEntity(3, null);
+        EntityHitResult entityHitResult = bot.getEntityHitResult(3, null);
         BlockHitResult blockHitResult = (BlockHitResult) bot.getRayTrace(5, ClipContext.Fluid.NONE);
-        boolean mainSuccess, useTo = entity != null, useOn = !bot.level().getBlockState(blockHitResult.getBlockPos()).isAir();
+        boolean mainSuccess, useTo = entityHitResult != null, useOn = !bot.level().getBlockState(blockHitResult.getBlockPos()).isAir();
         if (useTo) {
-            mainSuccess = ServerUseItemToAction.execute(bot, entity);
+            InteractionResult result = ServerUseItemToAction.execute(bot, entityHitResult);
+            mainSuccess = result.consumesAction() || result == InteractionResult.PASS && ServerUseItemAction.execute(bot);
         } else if (useOn) {
             mainSuccess = ServerUseItemOnAction.execute(bot, blockHitResult) || ServerUseItemAction.execute(bot);
         } else {
@@ -88,7 +91,8 @@ public class ServerUseItemAutoAction extends ServerTimerBotAction<ServerUseItemA
             return true;
         }
         if (useTo) {
-            return ServerUseItemToOffhandAction.execute(bot, entity);
+            InteractionResult result = ServerUseItemToOffhandAction.execute(bot, entityHitResult);
+            return result.consumesAction() || result == InteractionResult.PASS && ServerUseItemOffhandAction.execute(bot);
         } else if (useOn) {
             return ServerUseItemOnOffhandAction.execute(bot, blockHitResult) || ServerUseItemOffhandAction.execute(bot);
         } else {

--- a/leaves-server/src/main/java/org/leavesmc/leaves/bot/agent/actions/ServerUseItemAutoAction.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/bot/agent/actions/ServerUseItemAutoAction.java
@@ -91,7 +91,7 @@ public class ServerUseItemAutoAction extends ServerTimerBotAction<ServerUseItemA
         }
         if (useTo) {
             InteractionResult result = ServerUseItemToOffhandAction.execute(bot, entityHitResult);
-            return result.consumesAction() || result == InteractionResult.PASS && ServerUseItemOffhandAction.execute(bot);
+            return result.consumesAction() || (result == InteractionResult.PASS && ServerUseItemOffhandAction.execute(bot));
         } else if (useOn) {
             return ServerUseItemOnOffhandAction.execute(bot, blockHitResult) || ServerUseItemOffhandAction.execute(bot);
         } else {

--- a/leaves-server/src/main/java/org/leavesmc/leaves/bot/agent/actions/ServerUseItemOnAction.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/bot/agent/actions/ServerUseItemOnAction.java
@@ -101,23 +101,23 @@ public class ServerUseItemOnAction extends ServerTimerBotAction<ServerUseItemOnA
         BlockState state = bot.level().getBlockState(blockHitResult.getBlockPos());
         if (state.isAir()) {
             return false;
-        } else {
-            bot.swing(InteractionHand.MAIN_HAND);
-            if (state.getBlock() == Blocks.TRAPPED_CHEST) {
-                BlockEntity entity = bot.level().getBlockEntity(blockHitResult.getBlockPos());
-                if (entity instanceof TrappedChestBlockEntity chestBlockEntity) {
-                    chestBlockEntity.startOpen(bot);
-                    Bukkit.getScheduler().runTaskLater(MinecraftInternalPlugin.INSTANCE, () -> chestBlockEntity.stopOpen(bot), 1);
-                    return true;
-                } else {
-                    return false;
-                }
-
-            } else {
-                bot.updateItemInHand(InteractionHand.MAIN_HAND);
-                return bot.gameMode.useItemOn(bot, bot.level(), bot.getItemInHand(InteractionHand.MAIN_HAND), InteractionHand.MAIN_HAND, blockHitResult).consumesAction();
-            }
         }
+
+        boolean success;
+        if (state.getBlock() == Blocks.TRAPPED_CHEST &&
+            bot.level().getBlockEntity(blockHitResult.getBlockPos()) instanceof TrappedChestBlockEntity chestBlockEntity
+        ) {
+            chestBlockEntity.startOpen(bot);
+            Bukkit.getScheduler().runTaskLater(MinecraftInternalPlugin.INSTANCE, () -> chestBlockEntity.stopOpen(bot), 1);
+            success = true;
+        } else {
+            bot.updateItemInHand(InteractionHand.MAIN_HAND);
+            success = bot.gameMode.useItemOn(bot, bot.level(), bot.getItemInHand(InteractionHand.MAIN_HAND), InteractionHand.MAIN_HAND, blockHitResult).consumesAction();
+        }
+        if (success) {
+            bot.swing(InteractionHand.MAIN_HAND);
+        }
+        return success;
     }
 
     @Override

--- a/leaves-server/src/main/java/org/leavesmc/leaves/bot/agent/actions/ServerUseItemOnAction.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/bot/agent/actions/ServerUseItemOnAction.java
@@ -5,7 +5,6 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.level.ClipContext;
 import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.TrappedChestBlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;

--- a/leaves-server/src/main/java/org/leavesmc/leaves/bot/agent/actions/ServerUseItemOnOffhandAction.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/bot/agent/actions/ServerUseItemOnOffhandAction.java
@@ -94,30 +94,30 @@ public class ServerUseItemOnOffhandAction extends ServerTimerBotAction<ServerUse
         this.useTick = useTick;
     }
 
-    public static boolean execute(ServerBot bot, HitResult result) {
+    public static boolean execute(@NotNull ServerBot bot, HitResult result) {
         if (!(result instanceof BlockHitResult blockHitResult)) {
             return false;
         }
-
         BlockState state = bot.level().getBlockState(blockHitResult.getBlockPos());
         if (state.isAir()) {
             return false;
-        } else {
-            bot.swing(InteractionHand.OFF_HAND);
-            if (state.getBlock() == Blocks.TRAPPED_CHEST) {
-                BlockEntity entity = bot.level().getBlockEntity(blockHitResult.getBlockPos());
-                if (entity instanceof TrappedChestBlockEntity chestBlockEntity) {
-                    chestBlockEntity.startOpen(bot);
-                    Bukkit.getScheduler().runTaskLater(MinecraftInternalPlugin.INSTANCE, () -> chestBlockEntity.stopOpen(bot), 1);
-                    return true;
-                } else {
-                    return false;
-                }
-            } else {
-                bot.updateItemInHand(InteractionHand.OFF_HAND);
-                return bot.gameMode.useItemOn(bot, bot.level(), bot.getItemInHand(InteractionHand.OFF_HAND), InteractionHand.OFF_HAND, blockHitResult).consumesAction();
-            }
         }
+
+        boolean success;
+        if (state.getBlock() == Blocks.TRAPPED_CHEST &&
+            bot.level().getBlockEntity(blockHitResult.getBlockPos()) instanceof TrappedChestBlockEntity chestBlockEntity
+        ) {
+            chestBlockEntity.startOpen(bot);
+            Bukkit.getScheduler().runTaskLater(MinecraftInternalPlugin.INSTANCE, () -> chestBlockEntity.stopOpen(bot), 1);
+            success = true;
+        } else {
+            bot.updateItemInHand(InteractionHand.OFF_HAND);
+            success = bot.gameMode.useItemOn(bot, bot.level(), bot.getItemInHand(InteractionHand.OFF_HAND), InteractionHand.OFF_HAND, blockHitResult).consumesAction();
+        }
+        if (success) {
+            bot.swing(InteractionHand.OFF_HAND);
+        }
+        return success;
     }
 
     @Override

--- a/leaves-server/src/main/java/org/leavesmc/leaves/bot/agent/actions/ServerUseItemOnOffhandAction.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/bot/agent/actions/ServerUseItemOnOffhandAction.java
@@ -5,7 +5,6 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.level.ClipContext;
 import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.TrappedChestBlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;

--- a/leaves-server/src/main/java/org/leavesmc/leaves/bot/agent/actions/ServerUseItemToAction.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/bot/agent/actions/ServerUseItemToAction.java
@@ -3,7 +3,6 @@ package org.leavesmc.leaves.bot.agent.actions;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
-import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.decoration.ArmorStand;
 import net.minecraft.world.phys.EntityHitResult;
 import org.apache.commons.lang3.tuple.Pair;

--- a/leaves-server/src/main/java/org/leavesmc/leaves/bot/agent/actions/ServerUseItemToOffhandAction.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/bot/agent/actions/ServerUseItemToOffhandAction.java
@@ -3,7 +3,6 @@ package org.leavesmc.leaves.bot.agent.actions;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
-import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.decoration.ArmorStand;
 import net.minecraft.world.phys.EntityHitResult;
 import org.apache.commons.lang3.tuple.Pair;
@@ -12,7 +11,6 @@ import org.leavesmc.leaves.bot.ServerBot;
 import org.leavesmc.leaves.command.CommandArgument;
 import org.leavesmc.leaves.command.CommandArgumentResult;
 import org.leavesmc.leaves.command.CommandArgumentType;
-import org.leavesmc.leaves.entity.bot.actions.CraftUseItemToAction;
 import org.leavesmc.leaves.entity.bot.actions.CraftUseItemToOffhandAction;
 import org.leavesmc.leaves.event.bot.BotActionStopEvent;
 


### PR DESCRIPTION
所有的修复（一切以原版玩家行为为准）:
1. 假人面对盔甲架时调用特殊的interact方法（修复 #605，可放上或取下装备）
2. 假人面对实体可以喂食 喂食失败则自行食用
3. 假人空手与方块交互不再挥手

优化了一部分的代码逻辑