### PR TITLE
[ci skip] fix: fix push to api fail when commit contains double quotation marks

### DIFF
--- a/scripts/PushToAPI.sh
+++ b/scripts/PushToAPI.sh
@@ -17,7 +17,7 @@ else
 fi
 
 number=$(git log --oneline master ^"$(git describe --tags --abbrev=0)" | wc -l)
-changes=$(git log --pretty='%H<<<%s>>>' -"$number" | sed ':a;N;$!ba;s/\n//g')
+changes=$(git log --pretty='%H<<<%s>>>' -"$number" | sed ':a;N;$!ba;s/\n//g' | sed 's/"/\\"/g')
 jar_name="leaves-$mcversion.jar"
 jar_sha256=$(sha256 "$jar_name")
 


### PR DESCRIPTION
修复了 commit msg 中含有双引号时未转义导致的 pushToApi 失败
经过单独的测试未发现问题，转义正常
```log
$ git log --pretty='%H<<<%s>>>' -2 | sed ':a;N;$!ba;s/\n//g' | sed 's/"/\\"/g'
e298d0978ad8ae2fe17358bfbc4b7b82b208540f<<<[ci skip] fix: fix patch name (#672)>>>678d4e20a7caab17aefc2a1f79a953b967cb8e70<<<Revert \"Fix bot cant get entity tracker (#670)\">>>
```