### PR TITLE
Try to fix replay api crash

### DIFF
--- a/leaves-server/src/main/java/org/leavesmc/leaves/replay/Recorder.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/replay/Recorder.java
@@ -65,8 +65,8 @@ public class Recorder extends Connection {
     private final RecordMetaData metaData;
     private final AtomicBoolean isSaving = new AtomicBoolean(false);
 
-    private volatile boolean stopped = false;
-    private volatile boolean paused = false;
+    private boolean stopped = false;
+    private boolean paused = false;
     private boolean resumeOnNextPacket = true;
 
     private long startTime;


### PR DESCRIPTION
https://mclo.gs/B81bzNz

报错来看是 ClientboundLevelChunkPacketData.blockEntitiesData 在replay api encoding时被修改了
从源码上看 这个字段在创建后就不会动了

很明显 这里是在主线程处理encoding的 CME意味着有神秘插件在异步动了这个包内部的数据（据 @MC-XiaoHei 说是via，但via不应该能inject到摄像机的connection中）
这一定不是我们的bug 我们唯一能做的就是做好防崩和log报告