### PR TITLE
Do not check NaN values in entities (#742)

### DIFF
--- a/leaves-server/minecraft-patches/features/0141-Do-not-check-NaN-values-in-entities.patch
+++ b/leaves-server/minecraft-patches/features/0141-Do-not-check-NaN-values-in-entities.patch
@@ -1,0 +1,43 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Fortern <blueten.ki@gmail.com>
+Date: Mon, 29 Sep 2025 10:24:45 +0800
+Subject: [PATCH] Do not check NaN values in entities
+
+
+diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
+index 4748bd188f8860ed2a8b2e6123e020c1da17af5f..5c17fb5211da426b41c1ebb298563f083bc09099 100644
+--- a/net/minecraft/world/entity/Entity.java
++++ b/net/minecraft/world/entity/Entity.java
+@@ -2512,10 +2512,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+             }
+             } // CraftBukkit
+ 
+-            this.setDeltaMovement(io.papermc.paper.util.MCUtil.sanitizeNanInf(this.deltaMovement, 0D)); // Paper - remove NaN values before usage in saving
++            // Leaves start - Do not check NaN values
++            // this.setDeltaMovement(io.papermc.paper.util.MCUtil.sanitizeNanInf(this.deltaMovement, 0D)); // Paper - remove NaN values before usage in saving // Leaves - Do not check NaN values
+             output.store("Motion", Vec3.CODEC, this.getDeltaMovement());
+             // CraftBukkit start - Checking for NaN pitch/yaw and resetting to zero
+             // TODO: make sure this is the best way to address this.
++            /*
+             if (Float.isNaN(this.yRot)) {
+                 this.yRot = 0;
+             }
+@@ -2523,7 +2525,9 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+             if (Float.isNaN(this.xRot)) {
+                 this.xRot = 0;
+             }
++            */
+             // CraftBukkit end
++            // Leaves end - Do not check NaN values
+             output.store("Rotation", Vec2.CODEC, new Vec2(this.getYRot(), this.getXRot()));
+             output.putDouble("fall_distance", this.fallDistance);
+             output.putShort("Fire", (short)this.remainingFireTicks);
+@@ -2646,7 +2650,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+     public void load(ValueInput input) {
+         try {
+             Vec3 vec3 = input.read("Pos", Vec3.CODEC).orElse(Vec3.ZERO);
+-            Vec3 vec31 = input.read("Motion", Vec3.CODEC).orElse(Vec3.ZERO); vec31 = io.papermc.paper.util.MCUtil.sanitizeNanInf(vec31, 0D); // Paper - avoid setting NaN values
++            Vec3 vec31 = input.read("Motion", Vec3.CODEC).orElse(Vec3.ZERO); // vec31 = io.papermc.paper.util.MCUtil.sanitizeNanInf(vec31, 0D); // Paper - avoid setting NaN values // Leaves - Do not check NaN values
+             Vec2 vec2 = input.read("Rotation", Vec2.CODEC).orElse(Vec2.ZERO);
+             this.setDeltaMovement(Math.abs(vec31.x) > 10.0 ? 0.0 : vec31.x, Math.abs(vec31.y) > 10.0 ? 0.0 : vec31.y, Math.abs(vec31.z) > 10.0 ? 0.0 : vec31.z);
+             this.hasImpulse = true;


### PR DESCRIPTION
fix #742 

移除对实体中NaN数据的检查与重置，这样NaN矿车可以长时间稳定运行。