### PR TITLE
Avoid double creating stacktrace

### DIFF
--- a/leaves-server/minecraft-patches/features/0038-Catch-update-suppression-crash.patch
+++ b/leaves-server/minecraft-patches/features/0038-Catch-update-suppression-crash.patch
@@ -132,7 +132,7 @@ index e08083fbb6c3090c9a6f78dbbe487cbd4fec485a..4ed941783ed038df8e94ea92cdebb72b
  
      public static Block getBlockByColor(@Nullable DyeColor color) {
 diff --git a/net/minecraft/world/level/block/state/StateHolder.java b/net/minecraft/world/level/block/state/StateHolder.java
-index 040919c61ed29b3eda73b5d0f8ed905011e969a4..22dae9cf15fafda4b398025d85bad3e2a5965066 100644
+index 040919c61ed29b3eda73b5d0f8ed905011e969a4..9cedf0f7433d33f303463906d59c32382441d66e 100644
 --- a/net/minecraft/world/level/block/state/StateHolder.java
 +++ b/net/minecraft/world/level/block/state/StateHolder.java
 @@ -104,7 +104,16 @@ public abstract class StateHolder<O, S> implements ca.spottedleaf.moonrise.patch
@@ -144,7 +144,7 @@ index 040919c61ed29b3eda73b5d0f8ed905011e969a4..22dae9cf15fafda4b398025d85bad3e2
 +        IllegalArgumentException iae = new IllegalArgumentException("Cannot get property " + property + " as it does not exist in " + this.owner);
 +        if (org.leavesmc.leaves.LeavesConfig.modify.updateSuppressionCrashFix) {
 +            org.leavesmc.leaves.util.UpdateSuppressionException exception = new org.leavesmc.leaves.util.UpdateSuppressionException(null, null, null, null, iae);
-+            if (exception.getStackTrace()[1].getClassName().startsWith("net.minecraft")) {
++            if (iae.getStackTrace()[1].getClassName().startsWith("net.minecraft")) {
 +                throw exception;
 +            }
 +        }

--- a/leaves-server/src/main/java/org/leavesmc/leaves/util/UpdateSuppressionException.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/util/UpdateSuppressionException.java
@@ -122,4 +122,14 @@ public class UpdateSuppressionException extends RuntimeException {
         }
         return type.getSimpleName();
     }
+
+    @Override
+    public Throwable fillInStackTrace() {
+        return this;
+    }
+
+    @Override
+    public StackTraceElement[] getStackTrace() {
+        return this.throwable.getStackTrace(); // delegate to throwable as we don't have a stacktrace
+    }
 }


### PR DESCRIPTION
- UpdateSuppressionException重复填stacktrace的消耗太大了，关掉用原先捕获异常的stracktrace叭
- getStackTrace delegate到包装的异常