### PR TITLE
build: upgrade foojay-resolver-convention to 1.0.0 for Gradle 9 compa…

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,7 +7,7 @@ pluginManagement {
 }
 
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version("0.9.0")
+    id("org.gradle.toolchains.foojay-resolver-convention") version("1.0.0")
 }
 
 rootProject.name = "Leaves"


### PR DESCRIPTION
The current version of `foojay-resolver-convention`, `0.9.0`, is not compatible with the `gradle-9.2.1` version defined in `gradle-wrapper.properties`.

As a result, the build fails with the following error:

```
Exception java.lang.NoSuchFieldError: Class org.gradle.jvm.toolchain.JvmVendorSpec does not have member field 'org.gradle.jvm.toolchain.JvmVendorSpec IBM_SEMERU' [in thread "Daemon worker"]
```

Upgrading the plugin to version `1.0.0` successfully resolves the issue.

Plugin release notes:

> Version 1.0.0 (latest)
> Created 19 May 2025.
>
> * Plugin now compiled with Java 17, meaning it requires that version or higher to run
> * Removed direct references to deprecated `JvmVendorSpec.IBM_SEMERU`, to prepare for Gradle > 9 compatibility
> * Implementation dependencies are now shaded to reduce potential conflicts with other plugins

### Running Environment
- MacOS 26.2 (25C56)
- Eclipse Temurin 21.0.10 - aarch64
- arm64 M5 CPU
- Commit 97c7cbb2