### PR TITLE
Fix sign editing broken when container-passthrough enabled

### DIFF
--- a/leaves-server/minecraft-patches/features/0056-Container-open-passthrough.patch
+++ b/leaves-server/minecraft-patches/features/0056-Container-open-passthrough.patch
@@ -26,7 +26,7 @@ index 1b50d5a1c61fe15d06b3c1880e046c4a674df04e..9ca6e464c6f82cc7cf8d7ca8740f081a
                  if (flag1 && !this.isRemoved()) {
                      MapItemSavedData savedData = MapItem.getSavedData(itemInHand, this.level());
 diff --git a/net/minecraft/world/level/block/SignBlock.java b/net/minecraft/world/level/block/SignBlock.java
-index a2c6b0f85535b286c5649352f49e448ad587655c..3d62414778f8e18aebfa67817a86f188cb90c614 100644
+index a2c6b0f85535b286c5649352f49e448ad587655c..89214a418a4e745121530e70179e9d744b389916 100644
 --- a/net/minecraft/world/level/block/SignBlock.java
 +++ b/net/minecraft/world/level/block/SignBlock.java
 @@ -108,6 +108,18 @@ public abstract class SignBlock extends BaseEntityBlock implements SimpleWaterlo

--- a/leaves-server/minecraft-patches/features/0056-Container-open-passthrough.patch
+++ b/leaves-server/minecraft-patches/features/0056-Container-open-passthrough.patch
@@ -43,7 +43,7 @@ index a2c6b0f85535b286c5649352f49e448ad587655c..3d62414778f8e18aebfa67817a86f188
 +                        BlockState state1 = level.getBlockState(pos1);
 +                        return state1.useItemOn(stack, level, player, hand, hitResult.withPosition(pos1));
 +                    }
-+                    return InteractionResult.PASS;
++                    return InteractionResult.TRY_WITH_EMPTY_HAND;
 +                    // Leaves end - signContainerPassthrough
                  } else {
                      return InteractionResult.TRY_WITH_EMPTY_HAND;


### PR DESCRIPTION
借助 Claude 修复了 #821 ，发现是一个特别小的错误。

### 问题：

在 `0056-Container-open-passthrough.patch` 的 ` SignBlock.useItemOn ` 方法中，告示牌背后没有容器时，代码返回了 `InteractionResult.PASS` 而非 `InteractionResult.TRY_WITH_EMPTY_HAND`。

### 修复：

在补丁的第 46 行，将 `useItemOn` 方法中的 `return InteractionResult.PASS;` 改为 `return InteractionResult.TRY_WITH_EMPTY_HAND;`

这样一来，当告示牌背后没有容器时，交互会正确地流转到 `useWithoutItem`，潜行编辑告示牌的逻辑就能正常执行了。这是一个单行修复。
