### PR TITLE
Fix async keepalive semantics

### DIFF
--- a/leaves-server/minecraft-patches/features/0147-Async-keepalive.patch
+++ b/leaves-server/minecraft-patches/features/0147-Async-keepalive.patch
@@ -92,7 +92,7 @@ index 20b9dfe68dfbcd5bb999ee4ec0500bdf6bc7fdd5..77c42c748d930c975134cf033633a923
          // Paper start - improve keepalives
          if (this.checkIfClosed(millis) && !this.processedDisconnect) {
              long currTime = System.nanoTime();
-@@ -301,6 +336,30 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+@@ -301,6 +336,33 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
          Profiler.get().pop();
      }
  

--- a/leaves-server/minecraft-patches/features/0147-Async-keepalive.patch
+++ b/leaves-server/minecraft-patches/features/0147-Async-keepalive.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Haru Hyacinth <haru@MacBook-Air.local>
+From: Haru Hyacinth <HyacinthHaru@foxmail.com>
 Date: Fri, 20 Mar 2026 11:43:05 +0800
 Subject: [PATCH] Async keepalive
 

--- a/leaves-server/minecraft-patches/features/0147-Async-keepalive.patch
+++ b/leaves-server/minecraft-patches/features/0147-Async-keepalive.patch
@@ -40,25 +40,26 @@ index 20b9dfe68dfbcd5bb999ee4ec0500bdf6bc7fdd5..77c42c748d930c975134cf033633a923
          if (this.isSingleplayerOwner()) {
              LOGGER.info("Stopping singleplayer server as player logged out");
              this.server.halt(false);
-@@ -104,6 +108,12 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+@@ -104,6 +108,13 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
  
      @Override
      public void handleKeepAlive(ServerboundKeepAlivePacket packet) {
-+        // Leaves - 异步模式下由独立线程维护发送与超时，这里只处理响应。
++        // Leaves start - async keepalive
 +        if (org.leavesmc.leaves.LeavesConfig.mics.asyncKeepalive.enable) {
 +            this.handleAsyncKeepAlive(packet);
 +            return;
 +        }
++        // Leaves end - async keepalive
 +
          // Paper start - improve keepalives
          long now = System.nanoTime();
          io.papermc.paper.util.KeepAlive.PendingKeepAlive pending = this.keepAlive.pendingKeepAlives.peek();
-@@ -141,6 +150,28 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+@@ -141,6 +150,29 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
          // Paper end - improve keepalives
      }
  
++    // Leaves start - async keepalive
 +    private void handleAsyncKeepAlive(ServerboundKeepAlivePacket packet) {
-+        // Leaves - 允许在超时窗口内接受非队首响应，减少弱网乱序导致的误踢。
 +        long now = System.nanoTime();
 +        long timeoutNanos = java.util.concurrent.TimeUnit.MILLISECONDS.toNanos(org.leavesmc.leaves.LeavesConfig.mics.asyncKeepalive.getTimeoutMillis());
 +        for (java.util.Iterator<io.papermc.paper.util.KeepAlive.PendingKeepAlive> itr = this.keepAlive.pendingKeepAlives.iterator(); itr.hasNext();) {
@@ -78,20 +79,22 @@ index 20b9dfe68dfbcd5bb999ee4ec0500bdf6bc7fdd5..77c42c748d930c975134cf033633a923
 +            }
 +        }
 +    }
++    // Leaves end - async keepalive
 +
      @Override
      public void handlePong(ServerboundPongPacket packet) {
      }
-@@ -278,6 +308,12 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+@@ -278,6 +308,13 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
      protected void keepConnectionAlive() {
          Profiler.get().push("keepAlive");
          long millis = Util.getMillis();
-+        // Leaves - 异步模式下主线程只保留 closed 检查，其余逻辑交给异步线程。
++        // Leaves start - async keepalive
 +        if (org.leavesmc.leaves.LeavesConfig.mics.asyncKeepalive.enable) {
 +            this.checkIfClosed(millis);
 +            Profiler.get().pop();
 +            return;
 +        }
++        // Leaves end - async keepalive
          // Paper start - improve keepalives
          if (this.checkIfClosed(millis) && !this.processedDisconnect) {
              long currTime = System.nanoTime();
@@ -99,14 +102,13 @@ index 20b9dfe68dfbcd5bb999ee4ec0500bdf6bc7fdd5..77c42c748d930c975134cf033633a923
          Profiler.get().pop();
      }
  
++    // Leaves start - async keepalive
 +    public void leavesKeepConnectionAliveAsync(long currentTimeNs, long currentTimeMs) {
 +        if (this.closed || this.processedDisconnect || !this.connection.isConnected()) {
 +            return;
 +        }
 +
 +        long timeoutNanos = java.util.concurrent.TimeUnit.MILLISECONDS.toNanos(org.leavesmc.leaves.LeavesConfig.mics.asyncKeepalive.getTimeoutMillis());
-+
-+        // Leaves - 首次真正发出 keepalive 时才开始计时，避免连接建立时提前扣掉超时窗口。
 +        if ((currentTimeNs - this.keepAlive.lastKeepAliveTx) >= java.util.concurrent.TimeUnit.SECONDS.toNanos(1L)) {
 +            this.keepAlive.lastKeepAliveTx = currentTimeNs;
 +            if (this.leavesLastKeepAliveResponse == 0L) {
@@ -117,8 +119,6 @@ index 20b9dfe68dfbcd5bb999ee4ec0500bdf6bc7fdd5..77c42c748d930c975134cf033633a923
 +            this.keepAlive.pendingKeepAlives.add(pending);
 +            this.send(new ClientboundKeepAlivePacket(pending.challengeId()));
 +        }
-+
-+        // Leaves - 清理超时 pending，并按最近一次有效响应判断是否需要断开连接。
 +        while (this.keepAlive.pendingKeepAlives.pollIf((pending) -> (currentTimeNs - pending.txTimeNS()) > timeoutNanos) != null) {
 +        }
 +
@@ -127,6 +127,7 @@ index 20b9dfe68dfbcd5bb999ee4ec0500bdf6bc7fdd5..77c42c748d930c975134cf033633a923
 +            this.disconnectAsync(TIMEOUT_DISCONNECTION_MESSAGE, io.papermc.paper.connection.DisconnectionReason.TIMEOUT);
 +        }
 +    }
++    // Leaves end - async keepalive
 +
      private boolean checkIfClosed(long time) {
          if (this.closed) {

--- a/leaves-server/minecraft-patches/features/0147-Async-keepalive.patch
+++ b/leaves-server/minecraft-patches/features/0147-Async-keepalive.patch
@@ -1,11 +1,11 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Haru Hyacinth <HyacinthHaru@foxmail.com>
+From: HyacinthHaru <HyacinthHaru@foxmail.com>
 Date: Fri, 20 Mar 2026 11:43:05 +0800
 Subject: [PATCH] Async keepalive
 
 
 diff --git a/net/minecraft/server/network/ServerCommonPacketListenerImpl.java b/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
-index 20b9dfe68dfbcd5bb999ee4ec0500bdf6bc7fdd5..a6ef7839a10b9d2b56c6fdbded827a6d967fe7b4 100644
+index 20b9dfe68dfbcd5bb999ee4ec0500bdf6bc7fdd5..77c42c748d930c975134cf033633a92387de66a1 100644
 --- a/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
 +++ b/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
 @@ -29,6 +29,7 @@ import net.minecraft.server.players.NameAndId;
@@ -16,7 +16,15 @@ index 20b9dfe68dfbcd5bb999ee4ec0500bdf6bc7fdd5..a6ef7839a10b9d2b56c6fdbded827a6d
  
  public abstract class ServerCommonPacketListenerImpl implements ServerCommonPacketListener {
      private static final Logger LOGGER = LogUtils.getLogger();
-@@ -73,6 +74,7 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+@@ -46,6 +47,7 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+     private boolean closed = false;
+     private volatile int latency; // Paper - improve keepalives - make volatile
+     private final io.papermc.paper.util.KeepAlive keepAlive; // Paper - improve keepalives
++    private volatile long leaves$lastKeepAliveResponse = System.nanoTime(); // Leaves - async keepalive
+     private volatile boolean suspendFlushingOnServerThread = false;
+     // CraftBukkit start
+     public final org.bukkit.craftbukkit.CraftServer cserver;
+@@ -73,6 +75,7 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
          this.keepAlive = cookie.keepAlive();
          // Paper end
          this.profile = cookie.gameProfile(); // Leaves - protocol core
@@ -24,7 +32,7 @@ index 20b9dfe68dfbcd5bb999ee4ec0500bdf6bc7fdd5..a6ef7839a10b9d2b56c6fdbded827a6d
      }
  
      // Paper start - configuration phase API
-@@ -90,6 +92,7 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+@@ -90,6 +93,7 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
  
      @Override
      public void onDisconnect(DisconnectionDetails details) {
@@ -32,7 +40,7 @@ index 20b9dfe68dfbcd5bb999ee4ec0500bdf6bc7fdd5..a6ef7839a10b9d2b56c6fdbded827a6d
          if (this.isSingleplayerOwner()) {
              LOGGER.info("Stopping singleplayer server as player logged out");
              this.server.halt(false);
-@@ -104,6 +107,11 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+@@ -104,6 +108,11 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
  
      @Override
      public void handleKeepAlive(ServerboundKeepAlivePacket packet) {
@@ -44,42 +52,35 @@ index 20b9dfe68dfbcd5bb999ee4ec0500bdf6bc7fdd5..a6ef7839a10b9d2b56c6fdbded827a6d
          // Paper start - improve keepalives
          long now = System.nanoTime();
          io.papermc.paper.util.KeepAlive.PendingKeepAlive pending = this.keepAlive.pendingKeepAlives.peek();
-@@ -141,6 +149,34 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+@@ -141,6 +150,27 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
          // Paper end - improve keepalives
      }
  
 +    private void handleAsyncKeepAlive(ServerboundKeepAlivePacket packet) {
 +        long now = System.nanoTime();
-+        io.papermc.paper.util.KeepAlive.PendingKeepAlive matched = null;
-+
-+        for (io.papermc.paper.util.KeepAlive.PendingKeepAlive pending : this.keepAlive.pendingKeepAlives) {
++        long timeoutNanos = java.util.concurrent.TimeUnit.MILLISECONDS.toNanos(org.leavesmc.leaves.LeavesConfig.mics.asyncKeepalive.getTimeoutMillis());
++        for (java.util.Iterator<io.papermc.paper.util.KeepAlive.PendingKeepAlive> itr = this.keepAlive.pendingKeepAlives.iterator(); itr.hasNext();) {
++            io.papermc.paper.util.KeepAlive.PendingKeepAlive pending = itr.next();
 +            if (pending.challengeId() == packet.getId()) {
-+                matched = pending;
-+                break;
++                itr.remove();
++                if ((now - pending.txTimeNS()) > timeoutNanos) {
++                    return;
++                }
++
++                io.papermc.paper.util.KeepAlive.KeepAliveResponse response = new io.papermc.paper.util.KeepAlive.KeepAliveResponse(pending.txTimeNS(), now);
++                this.keepAlive.pingCalculator1m.update(response);
++                this.keepAlive.pingCalculator5s.update(response);
++                this.latency = this.keepAlive.pingCalculator5s.getAvgLatencyMS();
++                this.leaves$lastKeepAliveResponse = now;
++                return;
 +            }
 +        }
-+
-+        if (matched == null) {
-+            return;
-+        }
-+
-+        io.papermc.paper.util.KeepAlive.PendingKeepAlive pending;
-+        while ((pending = this.keepAlive.pendingKeepAlives.poll()) != null) {
-+            if (pending == matched) {
-+                break;
-+            }
-+        }
-+
-+        io.papermc.paper.util.KeepAlive.KeepAliveResponse response = new io.papermc.paper.util.KeepAlive.KeepAliveResponse(matched.txTimeNS(), now);
-+        this.keepAlive.pingCalculator1m.update(response);
-+        this.keepAlive.pingCalculator5s.update(response);
-+        this.latency = this.keepAlive.pingCalculator5s.getAvgLatencyMS();
 +    }
 +
      @Override
      public void handlePong(ServerboundPongPacket packet) {
      }
-@@ -278,6 +314,11 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+@@ -278,6 +308,11 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
      protected void keepConnectionAlive() {
          Profiler.get().push("keepAlive");
          long millis = Util.getMillis();
@@ -91,7 +92,7 @@ index 20b9dfe68dfbcd5bb999ee4ec0500bdf6bc7fdd5..a6ef7839a10b9d2b56c6fdbded827a6d
          // Paper start - improve keepalives
          if (this.checkIfClosed(millis) && !this.processedDisconnect) {
              long currTime = System.nanoTime();
-@@ -301,6 +342,26 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+@@ -301,6 +336,30 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
          Profiler.get().pop();
      }
  
@@ -99,6 +100,8 @@ index 20b9dfe68dfbcd5bb999ee4ec0500bdf6bc7fdd5..a6ef7839a10b9d2b56c6fdbded827a6d
 +        if (this.closed || this.processedDisconnect || !this.connection.isConnected()) {
 +            return;
 +        }
++
++        long timeoutNanos = java.util.concurrent.TimeUnit.MILLISECONDS.toNanos(org.leavesmc.leaves.LeavesConfig.mics.asyncKeepalive.getTimeoutMillis());
 +
 +        if ((currentTimeNs - this.keepAlive.lastKeepAliveTx) >= java.util.concurrent.TimeUnit.SECONDS.toNanos(1L)) {
 +            this.keepAlive.lastKeepAliveTx = currentTimeNs;
@@ -108,8 +111,10 @@ index 20b9dfe68dfbcd5bb999ee4ec0500bdf6bc7fdd5..a6ef7839a10b9d2b56c6fdbded827a6d
 +            this.send(new ClientboundKeepAlivePacket(pending.challengeId()));
 +        }
 +
-+        io.papermc.paper.util.KeepAlive.PendingKeepAlive oldest = this.keepAlive.pendingKeepAlives.peek();
-+        if (oldest != null && (currentTimeNs - oldest.txTimeNS()) > java.util.concurrent.TimeUnit.MILLISECONDS.toNanos(org.leavesmc.leaves.LeavesConfig.mics.asyncKeepalive.getTimeoutMillis())) {
++        while (this.keepAlive.pendingKeepAlives.pollIf((pending) -> (currentTimeNs - pending.txTimeNS()) > timeoutNanos) != null) {
++        }
++
++        if ((currentTimeNs - this.leaves$lastKeepAliveResponse) > timeoutNanos) {
 +            LOGGER.info("{} was kicked due to keepalive timeout!", this.playerProfile().name());
 +            this.disconnectAsync(TIMEOUT_DISCONNECTION_MESSAGE, io.papermc.paper.connection.DisconnectionReason.TIMEOUT);
 +        }

--- a/leaves-server/minecraft-patches/features/0147-Async-keepalive.patch
+++ b/leaves-server/minecraft-patches/features/0147-Async-keepalive.patch
@@ -20,7 +20,7 @@ index 20b9dfe68dfbcd5bb999ee4ec0500bdf6bc7fdd5..77c42c748d930c975134cf033633a923
      private boolean closed = false;
      private volatile int latency; // Paper - improve keepalives - make volatile
      private final io.papermc.paper.util.KeepAlive keepAlive; // Paper - improve keepalives
-+    private volatile long leavesLastKeepAliveResponse; // Leaves - async keepalive
++    private volatile long lastKeepAliveResponse; // Leaves - async keepalive
      private volatile boolean suspendFlushingOnServerThread = false;
      // CraftBukkit start
      public final org.bukkit.craftbukkit.CraftServer cserver;
@@ -74,7 +74,7 @@ index 20b9dfe68dfbcd5bb999ee4ec0500bdf6bc7fdd5..77c42c748d930c975134cf033633a923
 +                this.keepAlive.pingCalculator1m.update(response);
 +                this.keepAlive.pingCalculator5s.update(response);
 +                this.latency = this.keepAlive.pingCalculator5s.getAvgLatencyMS();
-+                this.leavesLastKeepAliveResponse = now;
++                this.lastKeepAliveResponse = now;
 +                return;
 +            }
 +        }
@@ -98,12 +98,12 @@ index 20b9dfe68dfbcd5bb999ee4ec0500bdf6bc7fdd5..77c42c748d930c975134cf033633a923
          // Paper start - improve keepalives
          if (this.checkIfClosed(millis) && !this.processedDisconnect) {
              long currTime = System.nanoTime();
-@@ -301,6 +336,35 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+@@ -301,6 +336,33 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
          Profiler.get().pop();
      }
  
 +    // Leaves start - async keepalive
-+    public void leavesKeepConnectionAliveAsync(long currentTimeNs, long currentTimeMs) {
++    public void keepConnectionAliveAsync(long currentTimeNs, long currentTimeMs) {
 +        if (this.closed || this.processedDisconnect || !this.connection.isConnected()) {
 +            return;
 +        }
@@ -111,8 +111,8 @@ index 20b9dfe68dfbcd5bb999ee4ec0500bdf6bc7fdd5..77c42c748d930c975134cf033633a923
 +        long timeoutNanos = java.util.concurrent.TimeUnit.MILLISECONDS.toNanos(org.leavesmc.leaves.LeavesConfig.mics.asyncKeepalive.getTimeoutMillis());
 +        if ((currentTimeNs - this.keepAlive.lastKeepAliveTx) >= java.util.concurrent.TimeUnit.SECONDS.toNanos(1L)) {
 +            this.keepAlive.lastKeepAliveTx = currentTimeNs;
-+            if (this.leavesLastKeepAliveResponse == 0L) {
-+                this.leavesLastKeepAliveResponse = currentTimeNs;
++            if (this.lastKeepAliveResponse == 0L) {
++                this.lastKeepAliveResponse = currentTimeNs;
 +            }
 +
 +            io.papermc.paper.util.KeepAlive.PendingKeepAlive pending = new io.papermc.paper.util.KeepAlive.PendingKeepAlive(currentTimeNs, currentTimeMs);
@@ -122,7 +122,7 @@ index 20b9dfe68dfbcd5bb999ee4ec0500bdf6bc7fdd5..77c42c748d930c975134cf033633a923
 +        while (this.keepAlive.pendingKeepAlives.pollIf((pending) -> (currentTimeNs - pending.txTimeNS()) > timeoutNanos) != null) {
 +        }
 +
-+        if (this.leavesLastKeepAliveResponse != 0L && (currentTimeNs - this.leavesLastKeepAliveResponse) > timeoutNanos) {
++        if (this.lastKeepAliveResponse != 0L && (currentTimeNs - this.lastKeepAliveResponse) > timeoutNanos) {
 +            LOGGER.info("{} was kicked due to keepalive timeout!", this.playerProfile().name());
 +            this.disconnectAsync(TIMEOUT_DISCONNECTION_MESSAGE, io.papermc.paper.connection.DisconnectionReason.TIMEOUT);
 +        }

--- a/leaves-server/minecraft-patches/features/0147-Async-keepalive.patch
+++ b/leaves-server/minecraft-patches/features/0147-Async-keepalive.patch
@@ -20,7 +20,7 @@ index 20b9dfe68dfbcd5bb999ee4ec0500bdf6bc7fdd5..77c42c748d930c975134cf033633a923
      private boolean closed = false;
      private volatile int latency; // Paper - improve keepalives - make volatile
      private final io.papermc.paper.util.KeepAlive keepAlive; // Paper - improve keepalives
-+    private volatile long leaves$lastKeepAliveResponse = System.nanoTime(); // Leaves - async keepalive
++    private volatile long leaves$lastKeepAliveResponse; // Leaves - async keepalive
      private volatile boolean suspendFlushingOnServerThread = false;
      // CraftBukkit start
      public final org.bukkit.craftbukkit.CraftServer cserver;
@@ -105,6 +105,9 @@ index 20b9dfe68dfbcd5bb999ee4ec0500bdf6bc7fdd5..77c42c748d930c975134cf033633a923
 +
 +        if ((currentTimeNs - this.keepAlive.lastKeepAliveTx) >= java.util.concurrent.TimeUnit.SECONDS.toNanos(1L)) {
 +            this.keepAlive.lastKeepAliveTx = currentTimeNs;
++            if (this.leaves$lastKeepAliveResponse == 0L) {
++                this.leaves$lastKeepAliveResponse = currentTimeNs;
++            }
 +
 +            io.papermc.paper.util.KeepAlive.PendingKeepAlive pending = new io.papermc.paper.util.KeepAlive.PendingKeepAlive(currentTimeNs, currentTimeMs);
 +            this.keepAlive.pendingKeepAlives.add(pending);
@@ -114,7 +117,7 @@ index 20b9dfe68dfbcd5bb999ee4ec0500bdf6bc7fdd5..77c42c748d930c975134cf033633a923
 +        while (this.keepAlive.pendingKeepAlives.pollIf((pending) -> (currentTimeNs - pending.txTimeNS()) > timeoutNanos) != null) {
 +        }
 +
-+        if ((currentTimeNs - this.leaves$lastKeepAliveResponse) > timeoutNanos) {
++        if (this.leaves$lastKeepAliveResponse != 0L && (currentTimeNs - this.leaves$lastKeepAliveResponse) > timeoutNanos) {
 +            LOGGER.info("{} was kicked due to keepalive timeout!", this.playerProfile().name());
 +            this.disconnectAsync(TIMEOUT_DISCONNECTION_MESSAGE, io.papermc.paper.connection.DisconnectionReason.TIMEOUT);
 +        }

--- a/leaves-server/minecraft-patches/features/0147-Async-keepalive.patch
+++ b/leaves-server/minecraft-patches/features/0147-Async-keepalive.patch
@@ -8,14 +8,6 @@ diff --git a/net/minecraft/server/network/ServerCommonPacketListenerImpl.java b/
 index 20b9dfe68dfbcd5bb999ee4ec0500bdf6bc7fdd5..77c42c748d930c975134cf033633a92387de66a1 100644
 --- a/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
 +++ b/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
-@@ -29,6 +29,7 @@ import net.minecraft.server.players.NameAndId;
- import net.minecraft.util.VisibleForDebug;
- import net.minecraft.util.profiling.Profiler;
- import org.slf4j.Logger;
-+import org.leavesmc.leaves.network.AsyncKeepaliveManager;
- 
- public abstract class ServerCommonPacketListenerImpl implements ServerCommonPacketListener {
-     private static final Logger LOGGER = LogUtils.getLogger();
 @@ -46,6 +47,7 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
      private boolean closed = false;
      private volatile int latency; // Paper - improve keepalives - make volatile
@@ -24,11 +16,12 @@ index 20b9dfe68dfbcd5bb999ee4ec0500bdf6bc7fdd5..77c42c748d930c975134cf033633a923
      private volatile boolean suspendFlushingOnServerThread = false;
      // CraftBukkit start
      public final org.bukkit.craftbukkit.CraftServer cserver;
-@@ -73,6 +75,7 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+@@ -73,6 +75,8 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
          this.keepAlive = cookie.keepAlive();
          // Paper end
          this.profile = cookie.gameProfile(); // Leaves - protocol core
-+        AsyncKeepaliveManager.register(this); // Leaves - async keepalive
++        this.lastKeepAliveResponse = this.keepAlive.lastKeepAliveTx; // Leaves - async keepalive
++        org.leavesmc.leaves.network.AsyncKeepaliveManager.register(this); // Leaves - async keepalive
      }
  
      // Paper start - configuration phase API
@@ -36,7 +29,7 @@ index 20b9dfe68dfbcd5bb999ee4ec0500bdf6bc7fdd5..77c42c748d930c975134cf033633a923
  
      @Override
      public void onDisconnect(DisconnectionDetails details) {
-+        AsyncKeepaliveManager.unregister(this); // Leaves - async keepalive
++        org.leavesmc.leaves.network.AsyncKeepaliveManager.unregister(this); // Leaves - async keepalive
          if (this.isSingleplayerOwner()) {
              LOGGER.info("Stopping singleplayer server as player logged out");
              this.server.halt(false);
@@ -98,7 +91,7 @@ index 20b9dfe68dfbcd5bb999ee4ec0500bdf6bc7fdd5..77c42c748d930c975134cf033633a923
          // Paper start - improve keepalives
          if (this.checkIfClosed(millis) && !this.processedDisconnect) {
              long currTime = System.nanoTime();
-@@ -301,6 +336,33 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+@@ -301,6 +336,29 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
          Profiler.get().pop();
      }
  
@@ -111,10 +104,6 @@ index 20b9dfe68dfbcd5bb999ee4ec0500bdf6bc7fdd5..77c42c748d930c975134cf033633a923
 +        long timeoutNanos = java.util.concurrent.TimeUnit.MILLISECONDS.toNanos(org.leavesmc.leaves.LeavesConfig.mics.asyncKeepalive.getTimeoutMillis());
 +        if ((currentTimeNs - this.keepAlive.lastKeepAliveTx) >= java.util.concurrent.TimeUnit.SECONDS.toNanos(1L)) {
 +            this.keepAlive.lastKeepAliveTx = currentTimeNs;
-+            if (this.lastKeepAliveResponse == 0L) {
-+                this.lastKeepAliveResponse = currentTimeNs;
-+            }
-+
 +            io.papermc.paper.util.KeepAlive.PendingKeepAlive pending = new io.papermc.paper.util.KeepAlive.PendingKeepAlive(currentTimeNs, currentTimeMs);
 +            this.keepAlive.pendingKeepAlives.add(pending);
 +            this.send(new ClientboundKeepAlivePacket(pending.challengeId()));
@@ -122,7 +111,7 @@ index 20b9dfe68dfbcd5bb999ee4ec0500bdf6bc7fdd5..77c42c748d930c975134cf033633a923
 +        while (this.keepAlive.pendingKeepAlives.pollIf((pending) -> (currentTimeNs - pending.txTimeNS()) > timeoutNanos) != null) {
 +        }
 +
-+        if (this.lastKeepAliveResponse != 0L && (currentTimeNs - this.lastKeepAliveResponse) > timeoutNanos) {
++        if ((currentTimeNs - this.lastKeepAliveResponse) > timeoutNanos) {
 +            LOGGER.info("{} was kicked due to keepalive timeout!", this.playerProfile().name());
 +            this.disconnectAsync(TIMEOUT_DISCONNECTION_MESSAGE, io.papermc.paper.connection.DisconnectionReason.TIMEOUT);
 +        }

--- a/leaves-server/minecraft-patches/features/0147-Async-keepalive.patch
+++ b/leaves-server/minecraft-patches/features/0147-Async-keepalive.patch
@@ -20,7 +20,7 @@ index 20b9dfe68dfbcd5bb999ee4ec0500bdf6bc7fdd5..77c42c748d930c975134cf033633a923
      private boolean closed = false;
      private volatile int latency; // Paper - improve keepalives - make volatile
      private final io.papermc.paper.util.KeepAlive keepAlive; // Paper - improve keepalives
-+    private volatile long leaves$lastKeepAliveResponse; // Leaves - async keepalive
++    private volatile long leavesLastKeepAliveResponse; // Leaves - async keepalive
      private volatile boolean suspendFlushingOnServerThread = false;
      // CraftBukkit start
      public final org.bukkit.craftbukkit.CraftServer cserver;
@@ -40,10 +40,11 @@ index 20b9dfe68dfbcd5bb999ee4ec0500bdf6bc7fdd5..77c42c748d930c975134cf033633a923
          if (this.isSingleplayerOwner()) {
              LOGGER.info("Stopping singleplayer server as player logged out");
              this.server.halt(false);
-@@ -104,6 +108,11 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+@@ -104,6 +108,12 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
  
      @Override
      public void handleKeepAlive(ServerboundKeepAlivePacket packet) {
++        // Leaves - 异步模式下由独立线程维护发送与超时，这里只处理响应。
 +        if (org.leavesmc.leaves.LeavesConfig.mics.asyncKeepalive.enable) {
 +            this.handleAsyncKeepAlive(packet);
 +            return;
@@ -52,11 +53,12 @@ index 20b9dfe68dfbcd5bb999ee4ec0500bdf6bc7fdd5..77c42c748d930c975134cf033633a923
          // Paper start - improve keepalives
          long now = System.nanoTime();
          io.papermc.paper.util.KeepAlive.PendingKeepAlive pending = this.keepAlive.pendingKeepAlives.peek();
-@@ -141,6 +150,27 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+@@ -141,6 +150,28 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
          // Paper end - improve keepalives
      }
  
 +    private void handleAsyncKeepAlive(ServerboundKeepAlivePacket packet) {
++        // Leaves - 允许在超时窗口内接受非队首响应，减少弱网乱序导致的误踢。
 +        long now = System.nanoTime();
 +        long timeoutNanos = java.util.concurrent.TimeUnit.MILLISECONDS.toNanos(org.leavesmc.leaves.LeavesConfig.mics.asyncKeepalive.getTimeoutMillis());
 +        for (java.util.Iterator<io.papermc.paper.util.KeepAlive.PendingKeepAlive> itr = this.keepAlive.pendingKeepAlives.iterator(); itr.hasNext();) {
@@ -71,7 +73,7 @@ index 20b9dfe68dfbcd5bb999ee4ec0500bdf6bc7fdd5..77c42c748d930c975134cf033633a923
 +                this.keepAlive.pingCalculator1m.update(response);
 +                this.keepAlive.pingCalculator5s.update(response);
 +                this.latency = this.keepAlive.pingCalculator5s.getAvgLatencyMS();
-+                this.leaves$lastKeepAliveResponse = now;
++                this.leavesLastKeepAliveResponse = now;
 +                return;
 +            }
 +        }
@@ -80,10 +82,11 @@ index 20b9dfe68dfbcd5bb999ee4ec0500bdf6bc7fdd5..77c42c748d930c975134cf033633a923
      @Override
      public void handlePong(ServerboundPongPacket packet) {
      }
-@@ -278,6 +308,11 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+@@ -278,6 +308,12 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
      protected void keepConnectionAlive() {
          Profiler.get().push("keepAlive");
          long millis = Util.getMillis();
++        // Leaves - 异步模式下主线程只保留 closed 检查，其余逻辑交给异步线程。
 +        if (org.leavesmc.leaves.LeavesConfig.mics.asyncKeepalive.enable) {
 +            this.checkIfClosed(millis);
 +            Profiler.get().pop();
@@ -92,21 +95,22 @@ index 20b9dfe68dfbcd5bb999ee4ec0500bdf6bc7fdd5..77c42c748d930c975134cf033633a923
          // Paper start - improve keepalives
          if (this.checkIfClosed(millis) && !this.processedDisconnect) {
              long currTime = System.nanoTime();
-@@ -301,6 +336,33 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+@@ -301,6 +336,35 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
          Profiler.get().pop();
      }
  
-+    public void leaves$keepConnectionAliveAsync(long currentTimeNs, long currentTimeMs) {
++    public void leavesKeepConnectionAliveAsync(long currentTimeNs, long currentTimeMs) {
 +        if (this.closed || this.processedDisconnect || !this.connection.isConnected()) {
 +            return;
 +        }
 +
 +        long timeoutNanos = java.util.concurrent.TimeUnit.MILLISECONDS.toNanos(org.leavesmc.leaves.LeavesConfig.mics.asyncKeepalive.getTimeoutMillis());
 +
++        // Leaves - 首次真正发出 keepalive 时才开始计时，避免连接建立时提前扣掉超时窗口。
 +        if ((currentTimeNs - this.keepAlive.lastKeepAliveTx) >= java.util.concurrent.TimeUnit.SECONDS.toNanos(1L)) {
 +            this.keepAlive.lastKeepAliveTx = currentTimeNs;
-+            if (this.leaves$lastKeepAliveResponse == 0L) {
-+                this.leaves$lastKeepAliveResponse = currentTimeNs;
++            if (this.leavesLastKeepAliveResponse == 0L) {
++                this.leavesLastKeepAliveResponse = currentTimeNs;
 +            }
 +
 +            io.papermc.paper.util.KeepAlive.PendingKeepAlive pending = new io.papermc.paper.util.KeepAlive.PendingKeepAlive(currentTimeNs, currentTimeMs);
@@ -114,10 +118,11 @@ index 20b9dfe68dfbcd5bb999ee4ec0500bdf6bc7fdd5..77c42c748d930c975134cf033633a923
 +            this.send(new ClientboundKeepAlivePacket(pending.challengeId()));
 +        }
 +
++        // Leaves - 清理超时 pending，并按最近一次有效响应判断是否需要断开连接。
 +        while (this.keepAlive.pendingKeepAlives.pollIf((pending) -> (currentTimeNs - pending.txTimeNS()) > timeoutNanos) != null) {
 +        }
 +
-+        if (this.leaves$lastKeepAliveResponse != 0L && (currentTimeNs - this.leaves$lastKeepAliveResponse) > timeoutNanos) {
++        if (this.leavesLastKeepAliveResponse != 0L && (currentTimeNs - this.leavesLastKeepAliveResponse) > timeoutNanos) {
 +            LOGGER.info("{} was kicked due to keepalive timeout!", this.playerProfile().name());
 +            this.disconnectAsync(TIMEOUT_DISCONNECTION_MESSAGE, io.papermc.paper.connection.DisconnectionReason.TIMEOUT);
 +        }

--- a/leaves-server/minecraft-patches/features/0147-Async-keepalive.patch
+++ b/leaves-server/minecraft-patches/features/0147-Async-keepalive.patch
@@ -1,0 +1,120 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Haru Hyacinth <haru@MacBook-Air.local>
+Date: Fri, 20 Mar 2026 11:43:05 +0800
+Subject: [PATCH] Async keepalive
+
+
+diff --git a/net/minecraft/server/network/ServerCommonPacketListenerImpl.java b/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
+index 20b9dfe68dfbcd5bb999ee4ec0500bdf6bc7fdd5..a6ef7839a10b9d2b56c6fdbded827a6d967fe7b4 100644
+--- a/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
++++ b/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
+@@ -29,6 +29,7 @@ import net.minecraft.server.players.NameAndId;
+ import net.minecraft.util.VisibleForDebug;
+ import net.minecraft.util.profiling.Profiler;
+ import org.slf4j.Logger;
++import org.leavesmc.leaves.network.AsyncKeepaliveManager;
+ 
+ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPacketListener {
+     private static final Logger LOGGER = LogUtils.getLogger();
+@@ -73,6 +74,7 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+         this.keepAlive = cookie.keepAlive();
+         // Paper end
+         this.profile = cookie.gameProfile(); // Leaves - protocol core
++        AsyncKeepaliveManager.register(this); // Leaves - async keepalive
+     }
+ 
+     // Paper start - configuration phase API
+@@ -90,6 +92,7 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+ 
+     @Override
+     public void onDisconnect(DisconnectionDetails details) {
++        AsyncKeepaliveManager.unregister(this); // Leaves - async keepalive
+         if (this.isSingleplayerOwner()) {
+             LOGGER.info("Stopping singleplayer server as player logged out");
+             this.server.halt(false);
+@@ -104,6 +107,11 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+ 
+     @Override
+     public void handleKeepAlive(ServerboundKeepAlivePacket packet) {
++        if (org.leavesmc.leaves.LeavesConfig.mics.asyncKeepalive.enable) {
++            this.handleAsyncKeepAlive(packet);
++            return;
++        }
++
+         // Paper start - improve keepalives
+         long now = System.nanoTime();
+         io.papermc.paper.util.KeepAlive.PendingKeepAlive pending = this.keepAlive.pendingKeepAlives.peek();
+@@ -141,6 +149,34 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+         // Paper end - improve keepalives
+     }
+ 
++    private void handleAsyncKeepAlive(ServerboundKeepAlivePacket packet) {
++        long now = System.nanoTime();
++        io.papermc.paper.util.KeepAlive.PendingKeepAlive matched = null;
++
++        for (io.papermc.paper.util.KeepAlive.PendingKeepAlive pending : this.keepAlive.pendingKeepAlives) {
++            if (pending.challengeId() == packet.getId()) {
++                matched = pending;
++                break;
++            }
++        }
++
++        if (matched == null) {
++            return;
++        }
++
++        io.papermc.paper.util.KeepAlive.PendingKeepAlive pending;
++        while ((pending = this.keepAlive.pendingKeepAlives.poll()) != null) {
++            if (pending == matched) {
++                break;
++            }
++        }
++
++        io.papermc.paper.util.KeepAlive.KeepAliveResponse response = new io.papermc.paper.util.KeepAlive.KeepAliveResponse(matched.txTimeNS(), now);
++        this.keepAlive.pingCalculator1m.update(response);
++        this.keepAlive.pingCalculator5s.update(response);
++        this.latency = this.keepAlive.pingCalculator5s.getAvgLatencyMS();
++    }
++
+     @Override
+     public void handlePong(ServerboundPongPacket packet) {
+     }
+@@ -278,6 +314,11 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+     protected void keepConnectionAlive() {
+         Profiler.get().push("keepAlive");
+         long millis = Util.getMillis();
++        if (org.leavesmc.leaves.LeavesConfig.mics.asyncKeepalive.enable) {
++            this.checkIfClosed(millis);
++            Profiler.get().pop();
++            return;
++        }
+         // Paper start - improve keepalives
+         if (this.checkIfClosed(millis) && !this.processedDisconnect) {
+             long currTime = System.nanoTime();
+@@ -301,6 +342,26 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+         Profiler.get().pop();
+     }
+ 
++    public void leaves$keepConnectionAliveAsync(long currentTimeNs, long currentTimeMs) {
++        if (this.closed || this.processedDisconnect || !this.connection.isConnected()) {
++            return;
++        }
++
++        if ((currentTimeNs - this.keepAlive.lastKeepAliveTx) >= java.util.concurrent.TimeUnit.SECONDS.toNanos(1L)) {
++            this.keepAlive.lastKeepAliveTx = currentTimeNs;
++
++            io.papermc.paper.util.KeepAlive.PendingKeepAlive pending = new io.papermc.paper.util.KeepAlive.PendingKeepAlive(currentTimeNs, currentTimeMs);
++            this.keepAlive.pendingKeepAlives.add(pending);
++            this.send(new ClientboundKeepAlivePacket(pending.challengeId()));
++        }
++
++        io.papermc.paper.util.KeepAlive.PendingKeepAlive oldest = this.keepAlive.pendingKeepAlives.peek();
++        if (oldest != null && (currentTimeNs - oldest.txTimeNS()) > java.util.concurrent.TimeUnit.MILLISECONDS.toNanos(org.leavesmc.leaves.LeavesConfig.mics.asyncKeepalive.getTimeoutMillis())) {
++            LOGGER.info("{} was kicked due to keepalive timeout!", this.playerProfile().name());
++            this.disconnectAsync(TIMEOUT_DISCONNECTION_MESSAGE, io.papermc.paper.connection.DisconnectionReason.TIMEOUT);
++        }
++    }
++
+     private boolean checkIfClosed(long time) {
+         if (this.closed) {
+             if (time - this.closedListenerTime >= 15000L) {

--- a/leaves-server/src/main/java/org/leavesmc/leaves/LeavesConfig.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/LeavesConfig.java
@@ -1089,6 +1089,31 @@ public final class LeavesConfig {
     @GlobalConfigCategory("misc")
     public static class MiscConfig {
 
+        public AsyncKeepaliveConfig asyncKeepalive = new AsyncKeepaliveConfig();
+
+        @GlobalConfigCategory("async-keepalive")
+        public static class AsyncKeepaliveConfig {
+
+            @GlobalConfig(value = "enable", lock = true)
+            public boolean enable = false;
+
+            @GlobalConfig(value = "timeout-seconds", lock = true, validator = TimeoutSecondsValidator.class)
+            public int timeoutSeconds = 20;
+
+            public long getTimeoutMillis() {
+                return this.timeoutSeconds * 1000L;
+            }
+
+            private static class TimeoutSecondsValidator extends IntConfigValidator {
+                @Override
+                public void verify(Integer old, Integer value) throws IllegalArgumentException {
+                    if (value <= 0) {
+                        throw new IllegalArgumentException("timeout-seconds need > 0");
+                    }
+                }
+            }
+        }
+
         public AutoUpdateConfig autoUpdate = new AutoUpdateConfig();
 
         @GlobalConfigCategory("auto-update")

--- a/leaves-server/src/main/java/org/leavesmc/leaves/network/AsyncKeepaliveManager.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/network/AsyncKeepaliveManager.java
@@ -50,7 +50,7 @@ public final class AsyncKeepaliveManager {
 
         for (ServerCommonPacketListenerImpl listener : ACTIVE_LISTENERS.values()) {
             try {
-                listener.leavesKeepConnectionAliveAsync(currentTimeNs, currentTimeMs);
+                listener.keepConnectionAliveAsync(currentTimeNs, currentTimeMs);
                 if (!listener.connection.isConnected() || listener.processedDisconnect) {
                     ACTIVE_LISTENERS.remove(listener.connection, listener);
                 }

--- a/leaves-server/src/main/java/org/leavesmc/leaves/network/AsyncKeepaliveManager.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/network/AsyncKeepaliveManager.java
@@ -50,7 +50,7 @@ public final class AsyncKeepaliveManager {
 
         for (ServerCommonPacketListenerImpl listener : ACTIVE_LISTENERS.values()) {
             try {
-                listener.leaves$keepConnectionAliveAsync(currentTimeNs, currentTimeMs);
+                listener.leavesKeepConnectionAliveAsync(currentTimeNs, currentTimeMs);
                 if (!listener.connection.isConnected() || listener.processedDisconnect) {
                     ACTIVE_LISTENERS.remove(listener.connection, listener);
                 }

--- a/leaves-server/src/main/java/org/leavesmc/leaves/network/AsyncKeepaliveManager.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/network/AsyncKeepaliveManager.java
@@ -1,0 +1,68 @@
+package org.leavesmc.leaves.network;
+
+import net.minecraft.Util;
+import net.minecraft.network.Connection;
+import net.minecraft.server.network.ServerCommonPacketListenerImpl;
+import org.leavesmc.leaves.LeavesConfig;
+import org.leavesmc.leaves.LeavesLogger;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+
+public final class AsyncKeepaliveManager {
+
+    private static final LeavesLogger LOGGER = LeavesLogger.LOGGER;
+    private static final Map<Connection, ServerCommonPacketListenerImpl> ACTIVE_LISTENERS = new ConcurrentHashMap<>();
+    private static final AtomicBoolean STARTED = new AtomicBoolean(false);
+    private static final ThreadFactory THREAD_FACTORY = runnable -> {
+        Thread thread = new Thread(runnable, "Leaves Async Keepalive");
+        thread.setDaemon(true);
+        return thread;
+    };
+    private static final ScheduledExecutorService EXECUTOR = Executors.newSingleThreadScheduledExecutor(THREAD_FACTORY);
+
+    private AsyncKeepaliveManager() {
+    }
+
+    public static void register(ServerCommonPacketListenerImpl listener) {
+        if (!LeavesConfig.mics.asyncKeepalive.enable) {
+            return;
+        }
+
+        ACTIVE_LISTENERS.put(listener.connection, listener);
+        if (STARTED.compareAndSet(false, true)) {
+            EXECUTOR.scheduleAtFixedRate(AsyncKeepaliveManager::tickAll, 1L, 1L, TimeUnit.SECONDS);
+        }
+    }
+
+    public static void unregister(ServerCommonPacketListenerImpl listener) {
+        if (!LeavesConfig.mics.asyncKeepalive.enable) {
+            return;
+        }
+
+        ACTIVE_LISTENERS.remove(listener.connection, listener);
+    }
+
+    private static void tickAll() {
+        long currentTimeNs = System.nanoTime();
+        long currentTimeMs = Util.getMillis();
+
+        for (ServerCommonPacketListenerImpl listener : ACTIVE_LISTENERS.values()) {
+            try {
+                listener.leaves$keepConnectionAliveAsync(currentTimeNs, currentTimeMs);
+                if (!listener.connection.isConnected() || listener.processedDisconnect) {
+                    ACTIVE_LISTENERS.remove(listener.connection, listener);
+                }
+            } catch (Throwable throwable) {
+                ACTIVE_LISTENERS.remove(listener.connection, listener);
+                LOGGER.log(Level.SEVERE, "Failed to run async keepalive for " + listener.getOwner().name(), throwable);
+            }
+        }
+    }
+}

--- a/leaves-server/src/main/java/org/leavesmc/leaves/network/AsyncKeepaliveManager.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/network/AsyncKeepaliveManager.java
@@ -60,7 +60,6 @@ public final class AsyncKeepaliveManager {
                     ACTIVE_LISTENERS.remove(listener.connection, listener);
                 }
             } catch (Throwable throwable) {
-                ACTIVE_LISTENERS.remove(listener.connection, listener);
                 LOGGER.log(Level.SEVERE, "Failed to run async keepalive for " + listener.getOwner().name(), throwable);
             }
         }

--- a/leaves-server/src/main/java/org/leavesmc/leaves/network/AsyncKeepaliveManager.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/network/AsyncKeepaliveManager.java
@@ -10,22 +10,24 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 
 public final class AsyncKeepaliveManager {
 
     private static final LeavesLogger LOGGER = LeavesLogger.LOGGER;
     private static final Map<Connection, ServerCommonPacketListenerImpl> ACTIVE_LISTENERS = new ConcurrentHashMap<>();
-    private static final AtomicBoolean STARTED = new AtomicBoolean(false);
-    private static final ThreadFactory THREAD_FACTORY = runnable -> {
+    private static final ScheduledExecutorService EXECUTOR = Executors.newSingleThreadScheduledExecutor(runnable -> {
         Thread thread = new Thread(runnable, "Leaves Async Keepalive");
         thread.setDaemon(true);
         return thread;
-    };
-    private static final ScheduledExecutorService EXECUTOR = Executors.newSingleThreadScheduledExecutor(THREAD_FACTORY);
+    });
+
+    static {
+        if (LeavesConfig.mics.asyncKeepalive.enable) {
+            EXECUTOR.scheduleAtFixedRate(AsyncKeepaliveManager::tickAll, 1L, 1L, TimeUnit.SECONDS);
+        }
+    }
 
     private AsyncKeepaliveManager() {
     }
@@ -36,16 +38,9 @@ public final class AsyncKeepaliveManager {
         }
 
         ACTIVE_LISTENERS.put(listener.connection, listener);
-        if (STARTED.compareAndSet(false, true)) {
-            EXECUTOR.scheduleAtFixedRate(AsyncKeepaliveManager::tickAll, 1L, 1L, TimeUnit.SECONDS);
-        }
     }
 
     public static void unregister(ServerCommonPacketListenerImpl listener) {
-        if (!LeavesConfig.mics.asyncKeepalive.enable) {
-            return;
-        }
-
         ACTIVE_LISTENERS.remove(listener.connection, listener);
     }
 
@@ -60,7 +55,8 @@ public final class AsyncKeepaliveManager {
                     ACTIVE_LISTENERS.remove(listener.connection, listener);
                 }
             } catch (Throwable throwable) {
-                LOGGER.log(Level.SEVERE, "Failed to run async keepalive for " + listener.getOwner().name(), throwable);
+                ACTIVE_LISTENERS.remove(listener.connection, listener);
+                LOGGER.log(Level.SEVERE, "Failed to run async keepalive for connection " + listener.connection.getRemoteAddress(), throwable);
             }
         }
     }


### PR DESCRIPTION
Fixes #813

实现可选的异步 KeepAlive 机制，用单独线程向客户端发送并检查 KeepAlive，降低主线程处理开销，同时为弱网玩家提供更宽松且更稳定的超时判定。

  ## 新增
  - 新增 `AsyncKeepaliveManager`，用于统一管理异步 KeepAlive 线程与活动连接
  - 新增异步 KeepAlive 配置项：
    - `misc.async-keepalive.enable`
    - `misc.async-keepalive.timeout-seconds`
  - 新增异步模式下的最近有效响应时间记录，用于更准确地实现“连续一段时间无有效响应才踢出”
  - 新增异步模式下对超时 pending KeepAlive 的清理逻辑，避免待响应队列持续堆积
  - 新增异步模式下的 KeepAlive 响应处理分支，并继续更新延迟统计数据

  ## 效果
  - 在启用后，服务器可以通过单独线程处理 KeepAlive，减少主线程上的 KeepAlive 工作
  - 玩家在异步模式下只要持续有有效 KeepAlive 响应，就不会因为短时乱序或单个旧包问题被错误踢出
  - 当玩家连续超过配置时间没有有效 KeepAlive 响应时，仍然会被正常判定超时踢出

  ## 目的
  - 为低带宽服务器提供更灵活的 KeepAlive 处理方式
  - 改善弱网、高延迟、响应抖动场景下的连接稳定性
  - 在放宽异步处理策略的同时，保持明确的超时边界与可控行为
