### PR TITLE
Fix async keepalive thread safety

### DIFF
--- a/leaves-server/minecraft-patches/features/0147-Async-keepalive.patch
+++ b/leaves-server/minecraft-patches/features/0147-Async-keepalive.patch
@@ -8,33 +8,39 @@ diff --git a/net/minecraft/server/network/ServerCommonPacketListenerImpl.java b/
 index 20b9dfe68dfbcd5bb999ee4ec0500bdf6bc7fdd5..77c42c748d930c975134cf033633a92387de66a1 100644
 --- a/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
 +++ b/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
-@@ -46,6 +47,7 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+@@ -46,6 +47,9 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
      private boolean closed = false;
-     private volatile int latency; // Paper - improve keepalives - make volatile
+     private volatile int latency; // Paper - improve keepalives
      private final io.papermc.paper.util.KeepAlive keepAlive; // Paper - improve keepalives
 +    private volatile long lastKeepAliveResponse; // Leaves - async keepalive
++    private volatile long lastAsyncKeepAliveTx; // Leaves - async keepalive
++    private final java.util.concurrent.ConcurrentHashMap<Long, Long> asyncPendingKeepAlives = new java.util.concurrent.ConcurrentHashMap<>(); // Leaves - async keepalive
      private volatile boolean suspendFlushingOnServerThread = false;
      // CraftBukkit start
      public final org.bukkit.craftbukkit.CraftServer cserver;
-@@ -73,6 +75,8 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+@@ -73,6 +77,11 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
          this.keepAlive = cookie.keepAlive();
          // Paper end
          this.profile = cookie.gameProfile(); // Leaves - protocol core
-+        this.lastKeepAliveResponse = this.keepAlive.lastKeepAliveTx; // Leaves - async keepalive
-+        org.leavesmc.leaves.network.AsyncKeepaliveManager.register(this); // Leaves - async keepalive
++        // Leaves start - async keepalive
++        long initTime = System.nanoTime();
++        this.lastAsyncKeepAliveTx = initTime;
++        this.lastKeepAliveResponse = initTime;
++        org.leavesmc.leaves.network.AsyncKeepaliveManager.register(this);
++        // Leaves end - async keepalive
      }
- 
+
      // Paper start - configuration phase API
-@@ -90,6 +93,7 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
- 
+@@ -90,6 +99,7 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+
      @Override
      public void onDisconnect(DisconnectionDetails details) {
 +        org.leavesmc.leaves.network.AsyncKeepaliveManager.unregister(this); // Leaves - async keepalive
          if (this.isSingleplayerOwner()) {
              LOGGER.info("Stopping singleplayer server as player logged out");
              this.server.halt(false);
-@@ -104,6 +108,13 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
- 
+@@ -104,6 +114,13 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+
      @Override
      public void handleKeepAlive(ServerboundKeepAlivePacket packet) {
 +        // Leaves start - async keepalive
@@ -47,30 +53,26 @@ index 20b9dfe68dfbcd5bb999ee4ec0500bdf6bc7fdd5..77c42c748d930c975134cf033633a923
          // Paper start - improve keepalives
          long now = System.nanoTime();
          io.papermc.paper.util.KeepAlive.PendingKeepAlive pending = this.keepAlive.pendingKeepAlives.peek();
-@@ -141,6 +150,29 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+@@ -141,6 +156,25 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
          // Paper end - improve keepalives
      }
- 
+
 +    // Leaves start - async keepalive
 +    private void handleAsyncKeepAlive(ServerboundKeepAlivePacket packet) {
++        Long txTimeNs = this.asyncPendingKeepAlives.remove(packet.getId());
++        if (txTimeNs == null) {
++            return;
++        }
 +        long now = System.nanoTime();
 +        long timeoutNanos = java.util.concurrent.TimeUnit.MILLISECONDS.toNanos(org.leavesmc.leaves.LeavesConfig.mics.asyncKeepalive.getTimeoutMillis());
-+        for (java.util.Iterator<io.papermc.paper.util.KeepAlive.PendingKeepAlive> itr = this.keepAlive.pendingKeepAlives.iterator(); itr.hasNext();) {
-+            io.papermc.paper.util.KeepAlive.PendingKeepAlive pending = itr.next();
-+            if (pending.challengeId() == packet.getId()) {
-+                itr.remove();
-+                if ((now - pending.txTimeNS()) > timeoutNanos) {
-+                    return;
-+                }
-+
-+                io.papermc.paper.util.KeepAlive.KeepAliveResponse response = new io.papermc.paper.util.KeepAlive.KeepAliveResponse(pending.txTimeNS(), now);
-+                this.keepAlive.pingCalculator1m.update(response);
-+                this.keepAlive.pingCalculator5s.update(response);
-+                this.latency = this.keepAlive.pingCalculator5s.getAvgLatencyMS();
-+                this.lastKeepAliveResponse = now;
-+                return;
-+            }
++        if ((now - txTimeNs) > timeoutNanos) {
++            return;
 +        }
++        io.papermc.paper.util.KeepAlive.KeepAliveResponse response = new io.papermc.paper.util.KeepAlive.KeepAliveResponse(txTimeNs, now);
++        this.keepAlive.pingCalculator1m.update(response);
++        this.keepAlive.pingCalculator5s.update(response);
++        this.latency = this.keepAlive.pingCalculator5s.getAvgLatencyMS();
++        this.lastKeepAliveResponse = now;
 +    }
 +    // Leaves end - async keepalive
 +
@@ -91,10 +93,10 @@ index 20b9dfe68dfbcd5bb999ee4ec0500bdf6bc7fdd5..77c42c748d930c975134cf033633a923
          // Paper start - improve keepalives
          if (this.checkIfClosed(millis) && !this.processedDisconnect) {
              long currTime = System.nanoTime();
-@@ -301,6 +336,29 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+@@ -301,6 +336,25 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
          Profiler.get().pop();
      }
- 
+
 +    // Leaves start - async keepalive
 +    public void keepConnectionAliveAsync(long currentTimeNs, long currentTimeMs) {
 +        if (this.closed || this.processedDisconnect || !this.connection.isConnected()) {
@@ -102,14 +104,12 @@ index 20b9dfe68dfbcd5bb999ee4ec0500bdf6bc7fdd5..77c42c748d930c975134cf033633a923
 +        }
 +
 +        long timeoutNanos = java.util.concurrent.TimeUnit.MILLISECONDS.toNanos(org.leavesmc.leaves.LeavesConfig.mics.asyncKeepalive.getTimeoutMillis());
-+        if ((currentTimeNs - this.keepAlive.lastKeepAliveTx) >= java.util.concurrent.TimeUnit.SECONDS.toNanos(1L)) {
-+            this.keepAlive.lastKeepAliveTx = currentTimeNs;
-+            io.papermc.paper.util.KeepAlive.PendingKeepAlive pending = new io.papermc.paper.util.KeepAlive.PendingKeepAlive(currentTimeNs, currentTimeMs);
-+            this.keepAlive.pendingKeepAlives.add(pending);
-+            this.send(new ClientboundKeepAlivePacket(pending.challengeId()));
++        if ((currentTimeNs - this.lastAsyncKeepAliveTx) >= java.util.concurrent.TimeUnit.SECONDS.toNanos(1L)) {
++            this.lastAsyncKeepAliveTx = currentTimeNs;
++            this.asyncPendingKeepAlives.put(currentTimeMs, currentTimeNs);
++            this.send(new ClientboundKeepAlivePacket(currentTimeMs));
 +        }
-+        while (this.keepAlive.pendingKeepAlives.pollIf((pending) -> (currentTimeNs - pending.txTimeNS()) > timeoutNanos) != null) {
-+        }
++        this.asyncPendingKeepAlives.values().removeIf(txTime -> (currentTimeNs - txTime) > timeoutNanos);
 +
 +        if ((currentTimeNs - this.lastKeepAliveResponse) > timeoutNanos) {
 +            LOGGER.info("{} was kicked due to keepalive timeout!", this.playerProfile().name());


### PR DESCRIPTION
## Summary
- Replace `MultiThreadedQueue.iterator().remove()` with `ConcurrentHashMap` for pending keepalive tracking, fixing `IllegalStateException` caused by concurrent queue modification between async keepalive thread and Netty I/O thread
- Introduce volatile `lastAsyncKeepAliveTx` to replace non-volatile `keepAlive.lastKeepAliveTx` for cross-thread send interval tracking
- Initialize timestamps from `System.nanoTime()` instead of shared KeepAlive state to avoid cross-thread visibility issues
- Completely isolate async keepalive state from Paper's internal `KeepAlive.pendingKeepAlives` queue

## Context
After #832, enabling `misc.async-keepalive.enable` causes all players to be disconnected with `Internal Exception: java.lang.IllegalStateException` within 1-2 seconds of joining. Root cause: `handleAsyncKeepAlive` iterates Paper's `MultiThreadedQueue` with `iterator().remove()` on the Netty I/O thread while `keepConnectionAliveAsync` concurrently modifies the same queue via `add()`/`pollIf()` on the async keepalive thread.

## Test plan
- [ ] Enable `misc.async-keepalive.enable` and verify players can join without `IllegalStateException`
- [ ] Verify keepalive timeout still kicks unresponsive players after configured timeout
- [ ] Verify ping/latency display remains accurate