### PR TITLE
修复僵尸猪灵“假愤怒”并停止移动

### DIFF
--- a/leaves-server/minecraft-patches/features/0141-Fix-stuck-zombified-piglin-anger-target.patch
+++ b/leaves-server/minecraft-patches/features/0141-Fix-stuck-zombified-piglin-anger-target.patch
@@ -4,11 +4,11 @@ Date: Tue, 28 Apr 2026 18:50:00 +0800
 Subject: [PATCH] Fix stuck zombified piglin anger target
 
 Cleans up the running anger timer whenever neither target nor
-persistentAngerTarget points to a living valid player.
+persistentAngerTarget points to a valid player.
 
 
 diff --git a/net/minecraft/world/entity/NeutralMob.java b/net/minecraft/world/entity/NeutralMob.java
-index c2201fde32aaf8cc02b71bc90aee40ef98438066..680374b0700e142edd435ae8e84cfd111aa883c4 100644
+index c2201fde32aaf8cc02b71bc90aee40ef98438066..beaad11820274a0bbaec121bc24d1c7dd9fb0230 100644
 --- a/net/minecraft/world/entity/NeutralMob.java
 +++ b/net/minecraft/world/entity/NeutralMob.java
 @@ -80,6 +80,22 @@ public interface NeutralMob {
@@ -18,12 +18,12 @@ index c2201fde32aaf8cc02b71bc90aee40ef98438066..680374b0700e142edd435ae8e84cfd11
 +
 +            // Leaves start - fix stuck zombified piglin anger target
 +            if (org.leavesmc.leaves.LeavesConfig.modify.fixStuckZombifiedPiglinAngerTarget && this.isAngry()) {
-+                boolean hasValidTargetPlayer = target != null && target.isAlive() && isValidPlayerTarget(target);
++                boolean hasValidTargetPlayer = target != null && isValidPlayerTarget(target);
 +                if (!hasValidTargetPlayer) {
 +                    boolean hasValidPersistentPlayer = false;
 +                    if (persistentAngerTarget != null) {
 +                        LivingEntity resolved = EntityReference.getLivingEntity(persistentAngerTarget, level);
-+                        hasValidPersistentPlayer = resolved != null && resolved.isAlive() && isValidPlayerTarget(resolved);
++                        hasValidPersistentPlayer = resolved != null && isValidPlayerTarget(resolved);
 +                    }
 +                    if (!hasValidPersistentPlayer) {
 +                        this.stopBeingAngry();

--- a/leaves-server/minecraft-patches/features/0141-Fix-stuck-zombified-piglin-anger-target.patch
+++ b/leaves-server/minecraft-patches/features/0141-Fix-stuck-zombified-piglin-anger-target.patch
@@ -3,25 +3,31 @@ From: HyacinthHaru <122684177+HyacinthHaru@users.noreply.github.com>
 Date: Tue, 28 Apr 2026 18:50:00 +0800
 Subject: [PATCH] Fix stuck zombified piglin anger target
 
-Cleans up the leftover persistentAngerTarget when target has been
-cleared but still resolves to a non-player Mob.
+Cleans up the running anger timer whenever neither target nor
+persistentAngerTarget points to a living valid player.
 
 
 diff --git a/net/minecraft/world/entity/NeutralMob.java b/net/minecraft/world/entity/NeutralMob.java
-index c2201fde32aaf8cc02b71bc90aee40ef98438066..e7ba7556326f9af7230392b31c7fc5f781419237 100644
+index c2201fde32aaf8cc02b71bc90aee40ef98438066..30d4e45baa188b7e7e1cf5eb9a76c17b950487e4 100644
 --- a/net/minecraft/world/entity/NeutralMob.java
 +++ b/net/minecraft/world/entity/NeutralMob.java
-@@ -80,6 +80,16 @@ public interface NeutralMob {
+@@ -80,6 +80,22 @@ public interface NeutralMob {
              if (persistentAngerTarget != null && !this.isAngry() && (target == null || !isValidPlayerTarget(target) || !updateAnger)) {
                  this.stopBeingAngry();
              }
 +
 +            // Leaves start - fix stuck zombified piglin anger target
-+            if (org.leavesmc.leaves.LeavesConfig.modify.oldMC.fixStuckZombifiedPiglinAngerTarget
-+                    && target == null && persistentAngerTarget != null) {
-+                LivingEntity resolved = EntityReference.getLivingEntity(persistentAngerTarget, level);
-+                if (resolved == null || !isValidPlayerTarget(resolved)) {
-+                    this.stopBeingAngry();
++            if (org.leavesmc.leaves.LeavesConfig.modify.oldMC.fixStuckZombifiedPiglinAngerTarget && this.isAngry()) {
++                boolean hasValidTargetPlayer = target != null && target.isAlive() && isValidPlayerTarget(target);
++                if (!hasValidTargetPlayer) {
++                    boolean hasValidPersistentPlayer = false;
++                    if (persistentAngerTarget != null) {
++                        LivingEntity resolved = EntityReference.getLivingEntity(persistentAngerTarget, level);
++                        hasValidPersistentPlayer = resolved != null && resolved.isAlive() && isValidPlayerTarget(resolved);
++                    }
++                    if (!hasValidPersistentPlayer) {
++                        this.stopBeingAngry();
++                    }
 +                }
 +            }
 +            // Leaves end - fix stuck zombified piglin anger target

--- a/leaves-server/minecraft-patches/features/0141-Fix-stuck-zombified-piglin-anger-target.patch
+++ b/leaves-server/minecraft-patches/features/0141-Fix-stuck-zombified-piglin-anger-target.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: HyacinthHaru <122684177+HyacinthHaru@users.noreply.github.com>
+Date: Tue, 28 Apr 2026 18:50:00 +0800
+Subject: [PATCH] Fix stuck zombified piglin anger target
+
+Cleans up the leftover persistentAngerTarget when target has been
+cleared but still resolves to a non-player Mob.
+
+
+diff --git a/net/minecraft/world/entity/NeutralMob.java b/net/minecraft/world/entity/NeutralMob.java
+index c2201fde32aaf8cc02b71bc90aee40ef98438066..e7ba7556326f9af7230392b31c7fc5f781419237 100644
+--- a/net/minecraft/world/entity/NeutralMob.java
++++ b/net/minecraft/world/entity/NeutralMob.java
+@@ -80,6 +80,16 @@ public interface NeutralMob {
+             if (persistentAngerTarget != null && !this.isAngry() && (target == null || !isValidPlayerTarget(target) || !updateAnger)) {
+                 this.stopBeingAngry();
+             }
++
++            // Leaves start - fix stuck zombified piglin anger target
++            if (org.leavesmc.leaves.LeavesConfig.modify.oldMC.fixStuckZombifiedPiglinAngerTarget
++                    && target == null && persistentAngerTarget != null) {
++                LivingEntity resolved = EntityReference.getLivingEntity(persistentAngerTarget, level);
++                if (resolved == null || !isValidPlayerTarget(resolved)) {
++                    this.stopBeingAngry();
++                }
++            }
++            // Leaves end - fix stuck zombified piglin anger target
+         }
+     }
+

--- a/leaves-server/minecraft-patches/features/0141-Fix-stuck-zombified-piglin-anger-target.patch
+++ b/leaves-server/minecraft-patches/features/0141-Fix-stuck-zombified-piglin-anger-target.patch
@@ -8,7 +8,7 @@ persistentAngerTarget points to a living valid player.
 
 
 diff --git a/net/minecraft/world/entity/NeutralMob.java b/net/minecraft/world/entity/NeutralMob.java
-index c2201fde32aaf8cc02b71bc90aee40ef98438066..30d4e45baa188b7e7e1cf5eb9a76c17b950487e4 100644
+index c2201fde32aaf8cc02b71bc90aee40ef98438066..680374b0700e142edd435ae8e84cfd111aa883c4 100644
 --- a/net/minecraft/world/entity/NeutralMob.java
 +++ b/net/minecraft/world/entity/NeutralMob.java
 @@ -80,6 +80,22 @@ public interface NeutralMob {
@@ -17,7 +17,7 @@ index c2201fde32aaf8cc02b71bc90aee40ef98438066..30d4e45baa188b7e7e1cf5eb9a76c17b
              }
 +
 +            // Leaves start - fix stuck zombified piglin anger target
-+            if (org.leavesmc.leaves.LeavesConfig.modify.oldMC.fixStuckZombifiedPiglinAngerTarget && this.isAngry()) {
++            if (org.leavesmc.leaves.LeavesConfig.modify.fixStuckZombifiedPiglinAngerTarget && this.isAngry()) {
 +                boolean hasValidTargetPlayer = target != null && target.isAlive() && isValidPlayerTarget(target);
 +                if (!hasValidTargetPlayer) {
 +                    boolean hasValidPersistentPlayer = false;

--- a/leaves-server/src/main/java/org/leavesmc/leaves/LeavesConfig.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/LeavesConfig.java
@@ -355,6 +355,9 @@ public final class LeavesConfig {
             @GlobalConfig("old-zombie-piglin-drop")
             public boolean oldZombiePiglinDrop = false;
 
+            @GlobalConfig("fix-stuck-zombified-piglin-anger-target")
+            public boolean fixStuckZombifiedPiglinAngerTarget = false;
+
             @TransferConfig(value = "modify.minecraft-old.revert-raid-changes", transformer = RaidConfigTransformer.class)
             @GlobalConfig("old-raid-behavior")
             public boolean oldRaidBehavior = false;

--- a/leaves-server/src/main/java/org/leavesmc/leaves/LeavesConfig.java
+++ b/leaves-server/src/main/java/org/leavesmc/leaves/LeavesConfig.java
@@ -355,9 +355,6 @@ public final class LeavesConfig {
             @GlobalConfig("old-zombie-piglin-drop")
             public boolean oldZombiePiglinDrop = false;
 
-            @GlobalConfig("fix-stuck-zombified-piglin-anger-target")
-            public boolean fixStuckZombifiedPiglinAngerTarget = false;
-
             @TransferConfig(value = "modify.minecraft-old.revert-raid-changes", transformer = RaidConfigTransformer.class)
             @GlobalConfig("old-raid-behavior")
             public boolean oldRaidBehavior = false;
@@ -598,6 +595,9 @@ public final class LeavesConfig {
 
         @GlobalConfig("fix-update-suppression-crash")
         public boolean updateSuppressionCrashFix = true;
+
+        @GlobalConfig("fix-stuck-zombified-piglin-anger-target")
+        public boolean fixStuckZombifiedPiglinAngerTarget = false;
 
         @GlobalConfig(value = "bedrock-break-list", lock = true)
         public boolean bedrockBreakList = false;


### PR DESCRIPTION
## 背景问题

玩家在任何僵尸猪灵密集的场所挂机一段时间后，会出现一些诡异的状态，包括僵尸猪灵愤怒音效一直响，但站在原地完全不移动、不攻击；视线随机转动（说明其 AI 未卡死）；打它一下，它就恢复正常，但周围其它猪灵还卡住；把整片区块卸载再加载，所有猪灵集体恢复，但挂一阵又复发。

这个问题在 1.21.11 版本才开始出现，而且不需要任何插件也能触发。Mojang 在 1.21.11 给僵尸猪灵加了投掷长矛攻击的能力，这使得猪灵之间会频繁互相“误伤”。

在如猪人塔一样密集的杀怪装置里，经常发生以下连锁：

``` 
猪灵 A 投长矛不小心打到同伴猪灵 B -> 
B 因此把 A 设为攻击目标，并把“持续愤怒”的目标锁定在 A 身上 -> 
玩家杀掉了 A（或 A 自然死亡） -> 
B 发现目标死了，于是把当前的攻击目标清掉，但它那个“持续愤怒”的对象还死死指着已经消失的 A -> 
原版的愤怒清理逻辑本应在这时候让它消气，但它只在“愤怒计时器自然到期”时才清理
```

但猪灵之间误伤是持续发生的，每次新的误伤都会刷新计时器，导致它永远等不到“自然消气”那一刻。

结果就是 B 陷入一个死循环：虽然愤怒，但目标已经不在了，而且逻辑永远不会主动帮它消气。这个状态不是 Leaves 特有的，Paper 上同样存在，是 Mojang 原版的设计缺陷。

## 这一 PR 做了什么

新增了一个配置项：`fix-stuck-zombified-piglin-anger-target`，放在了 `minecraft-old` 之下。

当开启时，服务端在每 tick 检查僵尸猪灵（以及其他中立生物）的愤怒状态时，追加一个清理判断，相当于恢复了 1.21.11 之前的判定逻辑。该修复只会在“目标已经不存在或不是一个活着的玩家”时才清空愤怒，不会误伤任何正常战斗流程。

当关闭时，回退到 1.21.11 Mojang 的默认逻辑（也就是默认这个 Bug 存在）

## 测试与关联

我们在实际运行的猪人塔服务器上部署了这套修复逻辑，挂机整夜未再出现“站着不动只叫”的现象。

关联：[PaperMC/Paper #13829](https://github.com/PaperMC/Paper/issues/13829)

[Mojang MC-305388](https://bugs.mojang.com/browse/MC-305388) 是同一个愤怒系统重构引发的另一个问题（蜜蜂不会消气），已在后续快照修复，但猪灵路径未覆盖
