### PR TITLE
fix #867

### DIFF
--- a/leaves-server/minecraft-patches/features/0100-Old-Block-remove-behaviour.patch
+++ b/leaves-server/minecraft-patches/features/0100-Old-Block-remove-behaviour.patch
@@ -762,10 +762,10 @@ index b1f1ea03072c63bc3032c9f023a8fb4ede34b34b..1d805ccd2bc9d74e8f15db37bcc8146b
              this.getBlock().affectNeighborsAfterRemoval(this.asState(), level, pos, movedByPiston);
          }
 diff --git a/net/minecraft/world/level/chunk/LevelChunk.java b/net/minecraft/world/level/chunk/LevelChunk.java
-index 670459abcc6f32bdc6d4742f6710585fda83ac83..3c5640ed649ba89066da70e64fe6291165948a5d 100644
+index 670459abcc6f32bdc6d4742f6710585fda83ac83..01be92e6b26aa754ba239fe0873d336319ec5c18 100644
 --- a/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/net/minecraft/world/level/chunk/LevelChunk.java
-@@ -401,22 +401,28 @@ public class LevelChunk extends ChunkAccess implements DebugValueSource, ca.spot
+@@ -401,22 +401,31 @@ public class LevelChunk extends ChunkAccess implements DebugValueSource, ca.spot
                  boolean flag = !blockState.is(block);
                  boolean flag1 = (flags & Block.UPDATE_MOVE_BY_PISTON) != 0;
                  boolean flag2 = (flags & Block.UPDATE_SKIP_BLOCK_ENTITY_SIDEEFFECTS) == 0;
@@ -776,7 +776,7 @@ index 670459abcc6f32bdc6d4742f6710585fda83ac83..3c5640ed649ba89066da70e64fe62911
 -                            blockEntity.preRemoveSideEffects(pos, blockState);
 +                // Leaves start - behaviour 1.21.1-
 +                if (!org.leavesmc.leaves.LeavesConfig.modify.oldMC.updater.oldBlockRemoveBehaviour) {
-+                    if (flag && blockState.hasBlockEntity()) {
++                    if (flag && blockState.hasBlockEntity() && !state.shouldChangedStateKeepBlockEntity(blockState)) {
 +                        if (!this.level.isClientSide() && flag2) {
 +                            BlockEntity blockEntity = this.level.getBlockEntity(pos);
 +                            if (blockEntity != null) {
@@ -800,7 +800,10 @@ index 670459abcc6f32bdc6d4742f6710585fda83ac83..3c5640ed649ba89066da70e64fe62911
 +                        blockState.affectNeighborsAfterRemoval(serverLevel, pos, flag1);
 +                    }
 +                } else {
-+                    blockState.onRemove(this.level, pos, state, flag1);
++                    // Leaves - behaviour 1.21.1- - keep the block entity when the changed state should preserve it (e.g. copper chest oxidation/scrape)
++                    if (!(flag && blockState.hasBlockEntity() && state.shouldChangedStateKeepBlockEntity(blockState))) {
++                        blockState.onRemove(this.level, pos, state, flag1);
++                    }
                  }
 +                // Leaves end - behaviour 1.21.1-
  

--- a/leaves-server/minecraft-patches/features/0100-Old-Block-remove-behaviour.patch
+++ b/leaves-server/minecraft-patches/features/0100-Old-Block-remove-behaviour.patch
@@ -762,7 +762,7 @@ index b1f1ea03072c63bc3032c9f023a8fb4ede34b34b..1d805ccd2bc9d74e8f15db37bcc8146b
              this.getBlock().affectNeighborsAfterRemoval(this.asState(), level, pos, movedByPiston);
          }
 diff --git a/net/minecraft/world/level/chunk/LevelChunk.java b/net/minecraft/world/level/chunk/LevelChunk.java
-index 670459abcc6f32bdc6d4742f6710585fda83ac83..01be92e6b26aa754ba239fe0873d336319ec5c18 100644
+index 670459abcc6f32bdc6d4742f6710585fda83ac83..dc3ec20474556590b1f2598c8772cc77ac47fb31 100644
 --- a/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -401,22 +401,31 @@ public class LevelChunk extends ChunkAccess implements DebugValueSource, ca.spot
@@ -800,8 +800,8 @@ index 670459abcc6f32bdc6d4742f6710585fda83ac83..01be92e6b26aa754ba239fe0873d3363
 +                        blockState.affectNeighborsAfterRemoval(serverLevel, pos, flag1);
 +                    }
 +                } else {
-+                    // Leaves - behaviour 1.21.1- - keep the block entity when the changed state should preserve it (e.g. copper chest oxidation/scrape)
-+                    if (!(flag && blockState.hasBlockEntity() && state.shouldChangedStateKeepBlockEntity(blockState))) {
++                    // Leaves - behaviour 1.21.1- - keep the block entity when the changed state should preserve it (e.g. copper chest / copper golem statue oxidation/scrape)
++                    if (!(blockState.hasBlockEntity() && state.shouldChangedStateKeepBlockEntity(blockState))) {
 +                        blockState.onRemove(this.level, pos, state, flag1);
 +                    }
                  }

--- a/leaves-server/minecraft-patches/features/0115-Do-not-prevent-block-entity-and-entity-crash-at-Leve.patch
+++ b/leaves-server/minecraft-patches/features/0115-Do-not-prevent-block-entity-and-entity-crash-at-Leve.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Do not prevent block entity and entity crash at LevelChunk
 
 
 diff --git a/net/minecraft/world/level/chunk/LevelChunk.java b/net/minecraft/world/level/chunk/LevelChunk.java
-index 3c5640ed649ba89066da70e64fe6291165948a5d..d5a0a2c0a5673088e4ad1e2e7f4fac8a65f68ceb 100644
+index 01be92e6b26aa754ba239fe0873d336319ec5c18..a2aa9dc8f7c3f386cbdc0c22cda4b7d3d02277e7 100644
 --- a/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/net/minecraft/world/level/chunk/LevelChunk.java
-@@ -982,12 +982,14 @@ public class LevelChunk extends ChunkAccess implements DebugValueSource, ca.spot
+@@ -985,12 +985,14 @@ public class LevelChunk extends ChunkAccess implements DebugValueSource, ca.spot
  
                          profilerFiller.pop();
                      } catch (Throwable var5) {

--- a/leaves-server/minecraft-patches/features/0131-Lithium-Sleeping-Block-Entity.patch
+++ b/leaves-server/minecraft-patches/features/0131-Lithium-Sleeping-Block-Entity.patch
@@ -2442,10 +2442,10 @@ index 1d805ccd2bc9d74e8f15db37bcc8146b846e438e..b6e232fa850d4b5aecc4fcf7a5efecee
      }
  
 diff --git a/net/minecraft/world/level/chunk/LevelChunk.java b/net/minecraft/world/level/chunk/LevelChunk.java
-index d5a0a2c0a5673088e4ad1e2e7f4fac8a65f68ceb..952311cc4d3dc9e1354bcbd08287005578b6352d 100644
+index a2aa9dc8f7c3f386cbdc0c22cda4b7d3d02277e7..8c485a8ed16a8f4d5921f2f1ce663e48e5e9ecb2 100644
 --- a/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/net/minecraft/world/level/chunk/LevelChunk.java
-@@ -928,12 +928,14 @@ public class LevelChunk extends ChunkAccess implements DebugValueSource, ca.spot
+@@ -931,12 +931,14 @@ public class LevelChunk extends ChunkAccess implements DebugValueSource, ca.spot
                      (pos, ticker1) -> {
                          TickingBlockEntity tickingBlockEntity = this.createTicker(blockEntity, ticker);
                          if (ticker1 != null) {
@@ -2460,7 +2460,7 @@ index d5a0a2c0a5673088e4ad1e2e7f4fac8a65f68ceb..952311cc4d3dc9e1354bcbd082870055
                              this.level.addBlockEntityTicker(rebindableTickingBlockEntityWrapper);
                              return rebindableTickingBlockEntityWrapper;
                          } else {
-@@ -1027,14 +1029,14 @@ public class LevelChunk extends ChunkAccess implements DebugValueSource, ca.spot
+@@ -1030,14 +1032,14 @@ public class LevelChunk extends ChunkAccess implements DebugValueSource, ca.spot
          void run(LevelChunk chunk);
      }
  


### PR DESCRIPTION
## #867 问题原因
铜箱子在氧化等级变化时会被替换成另一个 `Block` 实例。原版通过 `BlockState#shouldChangedStateKeepBlockEntity` 在此类状态切换中保留其
`BlockEntity`（连同内容物）。

但 `0100-Old-Block-remove-behaviour` 在改写
`LevelChunk#setBlockState` 的方块实体移除逻辑时丢失了这道守卫，就导致：

- 默认分支，条件被写成 `if (flag && blockState.hasBlockEntity())`，缺少
  `&& !state.shouldChangedStateKeepBlockEntity(blockState)`，致使氧化/除锈时
  `BlockEntity` 被移除、随后重建为空 BE → 内容物静默丢失。
- 旧行为分支，无条件 `blockState.onRemove(...)` →
  `ChestBlock#onRemove` → `Containers#dropContentsOnDestroy`，把物品爆出并移除 BE。

## 修改
在 `LevelChunk#setBlockState` 两条分支均尊重 `shouldChangedStateKeepBlockEntity`：
- 默认分支恢复原版守卫 `&& !state.shouldChangedStateKeepBlockEntity(blockState)`；
- 旧行为分支当该状态变化应保留 `BlockEntity` 时跳过 `onRemove`。

配合 patch 中既有的 `BlockEntityType#isValid` 放宽，保留下来的
`ChestBlockEntity` 会正确挂接到新氧化等级的铜箱子上，行为与原版一致。